### PR TITLE
chore: json split for LoadParcelScenes message

### DIFF
--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -60,8 +60,22 @@ const unityInterface = {
   LoadParcelScenes(parcelsToLoad: LoadableParcelScene[]) {
     const parcelScenes = JSON.stringify({ parcelsToLoad })
     if (parcelScenes !== lastParcelScenesSent) {
+
       lastParcelScenesSent = parcelScenes
-      gameInstance.SendMessage('SceneController', 'LoadParcelScenes', parcelScenes)
+      var finalJson: string = "";
+
+      //NOTE(Brian): split json to be able to throttle the json parsing process in engine's side
+      for (var i = 0; i < parcelsToLoad.length; i++) {
+        var parcel = parcelsToLoad[i]
+        const json = JSON.stringify(parcel)
+
+        finalJson += json;
+
+        if (i < parcelsToLoad.length - 1)
+          finalJson += "<break>"
+      }
+
+      gameInstance.SendMessage('SceneController', 'LoadParcelScenes', finalJson)
     }
   },
   sendSceneMessage(parcelSceneId: string, method: string, payload: string) {

--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -66,17 +66,18 @@ const unityInterface = {
     if (parcelScenes !== lastParcelScenesSent) {
 
       lastParcelScenesSent = parcelScenes
-      var finalJson: string = "";
+      let finalJson: string = "";
 
       //NOTE(Brian): split json to be able to throttle the json parsing process in engine's side
-      for (var i = 0; i < parcelsToLoad.length; i++) {
-        var parcel = parcelsToLoad[i]
+      for (let i = 0; i < parcelsToLoad.length; i++) {
+        const parcel = parcelsToLoad[i]
         const json = JSON.stringify(parcel)
 
         finalJson += json;
 
-        if (i < parcelsToLoad.length - 1)
+        if (i < parcelsToLoad.length - 1) {
           finalJson += "<break>"
+        }
       }
 
       gameInstance.SendMessage('SceneController', 'LoadParcelScenes', finalJson)

--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -76,7 +76,7 @@ const unityInterface = {
         finalJson += json;
 
         if (i < parcelsToLoad.length - 1) {
-          finalJson += "<break>"
+          finalJson += "}{"
         }
       }
 


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
This splits the LoadParcelScenes json with `<break>` statements. 

# Why? <!-- Explain the reason -->
This allows throttling the JSON parsing from game engine side, as its too big now and causes performance hiccups.
