### PR TITLE
chore: rename observer to observable

### DIFF
--- a/packages/dcl/WebGLParcelScene.ts
+++ b/packages/dcl/WebGLParcelScene.ts
@@ -15,7 +15,7 @@ import { WebGLScene } from './WebGLScene'
 import { isScreenSpaceComponent } from 'engine/components/helpers/ui'
 import { IEvents } from 'decentraland-ecs/src/decentraland/Types'
 import { camera, scene } from 'engine/renderer'
-import { positionObserver } from 'shared/world/positionThings'
+import { positionObservable } from 'shared/world/positionThings'
 
 const auxVec2 = BABYLON.Vector2.Zero()
 
@@ -99,7 +99,7 @@ export class WebGLParcelScene extends WebGLScene<LoadableParcelScene> {
 
     scene.onAfterRenderObservable.add(this.afterRender)
 
-    positionObserver.add(this.checkUserInPlace)
+    positionObservable.add(this.checkUserInPlace)
   }
 
   afterRender = () => {
@@ -127,7 +127,7 @@ export class WebGLParcelScene extends WebGLScene<LoadableParcelScene> {
   dispose(): void {
     super.dispose()
     scene.onAfterRenderObservable.removeCallback(this.afterRender)
-    positionObserver.removeCallback(this.checkUserInPlace)
+    positionObservable.removeCallback(this.checkUserInPlace)
   }
 
   /**

--- a/packages/dcl/api/ChatController.ts
+++ b/packages/dcl/api/ChatController.ts
@@ -7,7 +7,7 @@ import { chatObservable, ChatEvent } from 'shared/comms/chat'
 import { ExposableAPI } from 'shared/apis/ExposableAPI'
 import { IChatCommand, MessageEntry } from 'shared/types'
 import { EngineAPI } from 'shared/apis/EngineAPI'
-import { teleportObserver } from 'shared/world/positionThings'
+import { teleportObservable } from 'shared/world/positionThings'
 import {
   getCurrentUser,
   findPeerByName,
@@ -164,7 +164,7 @@ export class ChatController extends ExposableAPI implements IChatController {
       }
       const x = coordinates[1]
       const y = coordinates[2]
-      teleportObserver.notifyObservers({ x: parseInt(x, 10), y: parseInt(y, 10) })
+      teleportObservable.notifyObservers({ x: parseInt(x, 10), y: parseInt(y, 10) })
 
       return {
         id: v4(),

--- a/packages/dcl/index.ts
+++ b/packages/dcl/index.ts
@@ -7,7 +7,7 @@ import './api'
 // Our imports
 import { DEBUG, PREVIEW, NETWORK_HZ, EDITOR } from 'config'
 
-import { positionObserver, lastPlayerPosition } from 'shared/world/positionThings'
+import { positionObservable, lastPlayerPosition } from 'shared/world/positionThings'
 
 import { createStats } from './widgets/stats'
 import { Metrics, drawMetrics } from './widgets/metrics'
@@ -79,7 +79,7 @@ const notifyPositionObservers = (() => {
         quaternionToRotationBABYLON(quaternion, rotation)
       }
 
-      positionObserver.notifyObservers(objectToSend)
+      positionObservable.notifyObservers(objectToSend)
     }
   }
 })()

--- a/packages/engine/renderer/camera.ts
+++ b/packages/engine/renderer/camera.ts
@@ -4,7 +4,7 @@ import { vrHelper, scene, engine } from './init'
 import { playerConfigurations, visualConfigurations, parcelLimits } from 'config'
 import { keyState, Keys } from './input'
 import { gridToWorld } from 'atomicHelpers/parcelScenePositions'
-import { teleportObserver } from 'shared/world/positionThings'
+import { teleportObservable } from 'shared/world/positionThings'
 
 export const DEFAULT_CAMERA_ZOOM = 32
 export const MAX_CAMERA_ZOOM = 100
@@ -178,7 +178,7 @@ function unprojectToPlane(vec: BABYLON.Vector3) {
   return onPlane
 }
 
-teleportObserver.add((position: { x: number; y: number }) => {
+teleportObservable.add((position: { x: number; y: number }) => {
   return teleportTo(position.x, position.y)
 })
 

--- a/packages/shared/comms/index.ts
+++ b/packages/shared/comms/index.ts
@@ -2,7 +2,7 @@ import 'webrtc-adapter'
 
 import { parcelLimits, ETHEREUM_NETWORK, commConfigurations, networkConfigurations } from 'config'
 import { saveToLocalStorage } from 'atomicHelpers/localStorage'
-import { positionObserver } from 'shared/world/positionThings'
+import { positionObservable } from 'shared/world/positionThings'
 import { CommunicationArea, squareDistance, Position, position2parcel, sameParcel } from './utils'
 import { Stats, NetworkStats, PkgStats } from './debug'
 
@@ -343,7 +343,7 @@ export async function connect(ethAddress: string, network?: ETHEREUM_NETWORK) {
       }
     }, 1000)
 
-    positionObserver.add(
+    positionObservable.add(
       (
         obj: Readonly<{
           position: ReadOnlyVector3

--- a/packages/shared/world/parcelSceneManager.ts
+++ b/packages/shared/world/parcelSceneManager.ts
@@ -1,6 +1,6 @@
 import { initParcelSceneWorker } from '../../decentraland-loader/worker'
 import { ETHEREUM_NETWORK } from '../../config'
-import { positionObserver, teleportObserver } from './positionThings'
+import { positionObservable, teleportObservable } from './positionThings'
 import { worldToGrid } from '../../atomicHelpers/parcelScenePositions'
 import { SceneWorker, ParcelSceneAPI } from './SceneWorker'
 import { LoadableParcelScene, EnvironmentData, ILand, ILandToLoadableParcelScene } from '../types'
@@ -56,10 +56,10 @@ export async function enableParcelSceneLoading(network: ETHEREUM_NETWORK, option
     })
   }
 
-  teleportObserver.add((position: { x: number; y: number }) => {
+  teleportObservable.add((position: { x: number; y: number }) => {
     ret.server.notify('User.setPosition', { position })
   })
-  positionObserver.add(obj => {
+  positionObservable.add(obj => {
     worldToGrid(obj.position, position)
     ret.server.notify('User.setPosition', { position })
   })
@@ -84,7 +84,7 @@ export function enablePositionReporting() {
   isPositionReportingEnabled = true
   const position = Vector2.Zero()
 
-  positionObserver.add(obj => {
+  positionObservable.add(obj => {
     worldToGrid(obj.position, position)
     for (let parcelSceneWorker of loadedParcelSceneWorkers) {
       if (parcelSceneWorker && 'sendUserViewMatrix' in parcelSceneWorker) {

--- a/packages/shared/world/positionThings.ts
+++ b/packages/shared/world/positionThings.ts
@@ -10,7 +10,7 @@ import {
 } from 'decentraland-ecs/src/decentraland/math'
 import { Observable } from 'decentraland-ecs/src/ecs/Observable'
 
-export const positionObserver = new Observable<
+export const positionObservable = new Observable<
   Readonly<{
     position: ReadOnlyVector3
     rotation: ReadOnlyVector3
@@ -18,11 +18,11 @@ export const positionObserver = new Observable<
   }>
 >()
 
-export const teleportObserver = new Observable<ReadOnlyVector2>()
+export const teleportObservable = new Observable<ReadOnlyVector2>()
 
 export const lastPlayerPosition = new Vector3()
 
-positionObserver.add(event => {
+positionObservable.add(event => {
   lastPlayerPosition.copyFrom(event.position)
 })
 
@@ -53,7 +53,7 @@ export function initializeUrlPositionObserver() {
     }
   }
 
-  positionObserver.add(event => {
+  positionObservable.add(event => {
     updateUrlPosition(event.position)
   })
 

--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -3,7 +3,7 @@ type GameInstance = { SendMessage(object: string, method: string, ...args: (numb
 import { initShared } from '../shared'
 import { DevTools } from '../shared/apis/DevTools'
 import { ILogger, createLogger } from '../shared/logger'
-import { positionObserver, lastPlayerPosition } from '../shared/world/positionThings'
+import { positionObservable, lastPlayerPosition } from '../shared/world/positionThings'
 import { enableParcelSceneLoading, getParcelById } from '../shared/world/parcelSceneManager'
 import { IEventNames, IEvents } from '../decentraland-ecs/src/decentraland/Types'
 import { LoadableParcelScene, EntityAction, EnvironmentData, ILandToLoadableParcelScene } from '../shared/types'
@@ -30,7 +30,7 @@ const browserInterface = {
     positionEvent.position.set(data.position.x, data.position.y, data.position.z)
     positionEvent.quaternion.set(data.rotation.x, data.rotation.y, data.rotation.z, data.rotation.w)
     positionEvent.rotation.copyFrom(positionEvent.quaternion.eulerAngles)
-    positionObserver.notifyObservers(positionEvent)
+    positionObservable.notifyObservers(positionEvent)
   },
 
   SceneEvent(data: { sceneId: string; eventType: string; payload: any }) {


### PR DESCRIPTION
# Why? <!-- Explain the reason -->
The objects that are now being call "observers" are actually "observables" and using the `.add` function of them you can add **observers** to them.

why bother with this? If a programmer that isn't familiarized with observables pattern tries working in this code it will get very confusing.
