### PR TITLE
fix: children that dont have material dont count

### DIFF
--- a/packages/atomicHelpers/parcelScenePositions.ts
+++ b/packages/atomicHelpers/parcelScenePositions.ts
@@ -46,7 +46,7 @@ export function isOnLimits({ maximum, minimum }: BoundingInfo, parcels: Vector3C
   let minInside = false
   let maxInside = false
 
-  for (let i = 0; i < parcels.length; i++) {
+  for (let i = 0; i < parcels.length && (!minInside || !maxInside); i++) {
     maxInside = maxInside || isInParcel(maximum, parcels[i])
     minInside = minInside || isInParcel(minimum, parcels[i])
   }

--- a/packages/engine/dcl/WebGLParcelScene.ts
+++ b/packages/engine/dcl/WebGLParcelScene.ts
@@ -2,7 +2,7 @@ import { LoadableParcelScene, EnvironmentData } from 'shared/types'
 import { SceneWorker } from 'shared/world/SceneWorker'
 import { SharedSceneContext } from 'engine/entities/SharedSceneContext'
 import { getParcelSceneLimits } from 'atomicHelpers/landHelpers'
-import { DEBUG, EDITOR, PREVIEW } from 'config'
+import { DEBUG, EDITOR } from 'config'
 import { checkParcelSceneBoundaries } from '../entities/utils/checkParcelSceneLimits'
 import { BaseEntity } from 'engine/entities/BaseEntity'
 import { encodeParcelSceneBoundaries, gridToWorld, worldToGrid } from 'atomicHelpers/parcelScenePositions'
@@ -90,7 +90,7 @@ export class WebGLParcelScene extends WebGLScene<LoadableParcelScene> {
 
     if (DEBUG) {
       this.context.onEntityMatrixChangedObservable.add(_entity => {
-        this.shouldValidateBoundaries = !PREVIEW
+        this.shouldValidateBoundaries = true
       })
       this.initDebugEntities()
     }

--- a/packages/engine/entities/BaseEntity.ts
+++ b/packages/engine/entities/BaseEntity.ts
@@ -430,6 +430,7 @@ export class BaseEntity extends BABYLON.AbstractMesh {
     let min = boundingInfo.boundingBox.minimumWorld
     let max = boundingInfo.boundingBox.maximumWorld
     for (let i = 1; i < children.length; i++) {
+      // Cameras/lights doesn't have any materials and may be outside of the scene.
       if (!children[i].material) continue
       boundingInfo = children[i].getBoundingInfo()
       min = BABYLON.Vector3.Minimize(min, boundingInfo.boundingBox.minimumWorld)

--- a/packages/engine/entities/BaseEntity.ts
+++ b/packages/engine/entities/BaseEntity.ts
@@ -430,6 +430,7 @@ export class BaseEntity extends BABYLON.AbstractMesh {
     let min = boundingInfo.boundingBox.minimumWorld
     let max = boundingInfo.boundingBox.maximumWorld
     for (let i = 1; i < children.length; i++) {
+      if (!children[i].material) continue
       boundingInfo = children[i].getBoundingInfo()
       min = BABYLON.Vector3.Minimize(min, boundingInfo.boundingBox.minimumWorld)
       max = BABYLON.Vector3.Maximize(max, boundingInfo.boundingBox.maximumWorld)


### PR DESCRIPTION
A GLTF had a camera entity that was causing it to show as "fail" with impossible-to-debug conditions.