### PR TITLE
chore: only build modified ECS projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ test/out
 coverage
 
 public/local-ipfs
+ecs-stats.json

--- a/scripts/buildECSprojects.ts
+++ b/scripts/buildECSprojects.ts
@@ -17,8 +17,7 @@ const folders = glob
     .sync(path.resolve(__dirname, '../public/ecs-parcels/*/game.ts'), { absolute: true })
     .map($ => path.dirname($))
 
-  // tslint:disable-next-line: no-floating-promises
-;(async () => {
+async function main () {
   const [folderDates, ecsStatsExists] = await Promise.all([
     getLastModificationOfFolders(folders),
     fs.pathExists('ecs-stats.json')
@@ -43,7 +42,7 @@ const folders = glob
       stdio: 'inherit'
     }).ref()
   })
-})()
+}
 
 async function getLastModificationOfFolders(folders: string[]): Promise<any> {
   const result = {}
@@ -53,3 +52,8 @@ async function getLastModificationOfFolders(folders: string[]): Promise<any> {
   })
   return result
 }
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
Contributes to #148 

# What? <!-- what is this PR? -->
ECS Projects only are going to build in case of modification (even at first `make build`)

**TODO:** 
- [x] Calculate stat of child folder files
