### PR TITLE
fix: add timestamp field to tracking events

### DIFF
--- a/packages/shared/analytics.ts
+++ b/packages/shared/analytics.ts
@@ -36,15 +36,17 @@ export async function initialize(
 }
 
 export function queueTrackingEvent(eventName: string, eventData: any) {
+  const data = { ...eventData, time: new Date().toISOString() }
+
   if (DEBUG_ANALYTICS) {
-    console['log'](`Tracking event "${eventName}": `, eventData)
+    console['log'](`Tracking event "${eventName}": `, data)
   }
 
   if (!window.analytics) {
     return
   }
 
-  trackingQueue.push({ name: eventName, data: eventData })
+  trackingQueue.push({ name: eventName, data })
   if (!tracking) {
     startTracking()
   }


### PR DESCRIPTION
# What? <!-- what is this PR? -->
add timestamp field to tracking events

# Why? <!-- Explain the reason -->
because they are being queued to be sent to segment serially and the original segment timestamp could differ from the real action execution timestamp
