### PR TITLE
feat: support editor screenshot media types

### DIFF
--- a/packages/entryPoints/editor.ts
+++ b/packages/entryPoints/editor.ts
@@ -341,11 +341,11 @@ export namespace editor {
     return null
   }
 
-  export function takeScreenshot(): IFuture<string> {
+  export function takeScreenshot(mime: string = 'image/png'): IFuture<string> {
     const ret = future()
 
     scene.onAfterRenderObservable.addOnce(() => {
-      ret.resolve(canvas.toDataURL())
+      ret.resolve(canvas.toDataURL(mime))
     })
 
     return ret


### PR DESCRIPTION
Useful when generating webp images (used to generate webm videos).