### PR TITLE
Added params for benchmarking panels

### DIFF
--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -91,6 +91,8 @@ export const DEBUG_MOBILE = location.search.indexOf('DEBUG_MOBILE') !== -1
 export const DEBUG_METRICS = location.search.indexOf('DEBUG_METRICS') !== -1
 export const DEBUG_MESSAGES = location.search.indexOf('DEBUG_MESSAGES') !== -1
 export const DISABLE_AUTH = location.search.indexOf('DISABLE_AUTH') !== -1 || DEBUG
+export const BENCHMARK_DEV_PANEL = location.search.indexOf('BENCHMARK_DEV_PANEL') !== -1
+export const BENCHMARK_PANEL = location.search.indexOf('BENCHMARK_PANEL') !== -1 && !BENCHMARK_DEV_PANEL
 
 export namespace commConfigurations {
   export const debug = DEBUG_METRICS

--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -35,7 +35,7 @@ import { ensureUiApis } from '../shared/world/uiSceneInitializer'
 import { ParcelIdentity } from '../shared/apis/ParcelIdentity'
 import { IEventNames, IEvents } from '../decentraland-ecs/src/decentraland/Types'
 import { Vector3, Quaternion, ReadOnlyVector3, ReadOnlyQuaternion } from '../decentraland-ecs/src/decentraland/math'
-import { DEBUG, PREVIEW } from '../config'
+import { DEBUG, PREVIEW, BENCHMARK_DEV_PANEL, BENCHMARK_PANEL } from '../config'
 import { chatObservable } from '../shared/comms/chat'
 import { queueTrackingEvent } from '../shared/analytics'
 
@@ -123,6 +123,14 @@ const unityInterface = {
       console.log(parcelSceneId, method, payload)
     }
     gameInstance.SendMessage(`SceneController`, `SendSceneMessage`, `${parcelSceneId}\t${method}\t${payload}`)
+  },
+  
+  SetBenchmarkPanel(){
+	gameInstance.SendMessage('SceneController', 'SetBenchmark')
+  },
+  
+  SetBenchmarkDevPanel(){
+	gameInstance.SendMessage('SceneController', 'SetBenchmarkDev')
   }
 }
 
@@ -199,6 +207,14 @@ export async function initializeEngine(_gameInstance: GameInstance) {
   if (DEBUG) {
     unityInterface.SetDebug()
   }
+  
+  if(BENCHMARK_DEV_PANEL){	  
+	unityInterface.SetBenchmarkDevPanel();
+  }	  
+  
+  if(BENCHMARK_PANEL){
+	unityInterface.SetBenchmarkPanel();
+  }	  
 
   await initializeDecentralandUI()
 


### PR DESCRIPTION
https://github.com/decentraland/unity-client/issues/384

# What? <!-- what is this PR? -->
Params forwarded to Unity about benchmark panels visualization

# Why? <!-- Explain the reason -->
We dont want those panels to be enabled by default in production environments
