### PR TITLE
fix: report camera position unity

### DIFF
--- a/packages/entryPoints/preview.ts
+++ b/packages/entryPoints/preview.ts
@@ -85,11 +85,25 @@ namespace DCL {
 
     instancedJS
       .then(({ net, loadPreviewScene }) => {
+        // this is set to avoid double loading scenes due queued messages
+        let currentlyLoadingScene: Promise<any> | null = null
+
         global['handleServerMessage'] = function(message: any) {
           if (message.type === 'update') {
-            loadPreviewScene()
-              .then()
-              .catch(console.error)
+            // if a scene is currently loading we do not trigger another load
+            if (currentlyLoadingScene) return
+
+            currentlyLoadingScene = loadPreviewScene()
+
+            currentlyLoadingScene
+              .then(() => {
+                currentlyLoadingScene = null
+              })
+              .catch(err => {
+                currentlyLoadingScene = null
+                console.error('Error loading scene')
+                console.error(err)
+              })
           }
         }
 

--- a/packages/shared/world/parcelSceneManager.ts
+++ b/packages/shared/world/parcelSceneManager.ts
@@ -81,7 +81,7 @@ export async function enableParcelSceneLoading(network: ETHEREUM_NETWORK, option
   ret.on('Scene.shouldUnload', async (sceneCID: string) => {
     const parcelSceneToUnload = await ret.getParcelData(sceneCID)
     loadedParcelSceneWorkers.forEach($ => {
-      if (!$.persistent && $.parcelScene.data.id === parcelSceneToUnload.mappingsResponse.root_cid) {
+      if (!$.persistent && getParcelSceneCID($) === parcelSceneToUnload.mappingsResponse.root_cid) {
         $.dispose()
         loadedParcelSceneWorkers.delete($)
       }

--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -28,7 +28,8 @@ import {
   enableParcelSceneLoading,
   loadedParcelSceneWorkers,
   getSceneWorkerByBaseCoordinates,
-  getParcelSceneCID
+  getParcelSceneCID,
+  enablePositionReporting
 } from '../shared/world/parcelSceneManager'
 import { SceneWorker, ParcelSceneAPI, hudWorkerUrl } from '../shared/world/SceneWorker'
 import { ensureUiApis } from '../shared/world/uiSceneInitializer'
@@ -203,6 +204,7 @@ export async function initializeEngine(_gameInstance: GameInstance) {
   await initializeDecentralandUI()
 
   if (PREVIEW) {
+    enablePositionReporting()
     await loadPreviewScene()
   } else {
     await enableParcelSceneLoading(net, {
@@ -295,9 +297,7 @@ async function loadPreviewScene() {
     const parcelScene = new UnityParcelScene(ILandToLoadableParcelScene(defaultScene))
     const parcelSceneWorker = new SceneWorker(parcelScene)
 
-    if (parcelSceneWorker) {
-      loadedParcelSceneWorkers.add(parcelSceneWorker)
-    }
+    loadedParcelSceneWorkers.add(parcelSceneWorker)
 
     const target: LoadableParcelScene = { ...ILandToLoadableParcelScene(defaultScene).data }
     delete target.land

--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -17,6 +17,7 @@ import {
   ILand
 } from '../shared/types'
 import { DevTools } from '../shared/apis/DevTools'
+import { gridToWorld } from '../atomicHelpers/parcelScenePositions'
 import { ILogger, createLogger } from '../shared/logger'
 import {
   positionObservable,
@@ -177,6 +178,8 @@ class UnityParcelScene extends UnityScene<LoadableParcelScene> {
 
   registerWorker(worker: SceneWorker): void {
     super.registerWorker(worker)
+
+    gridToWorld(this.data.data.basePosition.x, this.data.data.basePosition.y, worker.position)
 
     this.worker.system
       .then(system => {


### PR DESCRIPTION
fix: report camera position unity and also fixes an annoying bug when the hot-reloading sends several messages in a row that created several workers and render them simultaneously 