### PR TITLE
fix: no parallelism because it breaks master build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
         environment:
           # avoid automatic download of LFS files
           GIT_LFS_SKIP_SMUDGE: 1
-    parallelism: 3
+    parallelism: 1
 
     working_directory: /tmp/explorer
     steps:


### PR DESCRIPTION

# What? <!-- what is this PR? -->
Parallelism for explorer dropped to 1
# Why?
It tries to publish to npm multiple times
