### PR TITLE
chore: added auto to transparency mode

### DIFF
--- a/packages/decentraland-ecs/src/decentraland/Components.ts
+++ b/packages/decentraland-ecs/src/decentraland/Components.ts
@@ -670,17 +670,18 @@ export class Material extends ObservableComponent {
 
   /**
    * Sets the transparency mode of the material.
-   * Defauts to 0.
+   * Defaults to -1.
    *
    * | Value | Type                                |
    * | ----- | ----------------------------------- |
+   * | -1    | AUTO  (Let the engine decide)       |
    * | 0     | OPAQUE  (default)                   |
    * | 1     | ALPHATEST                           |
    * | 2     | ALPHABLEND                          |
    * | 3     | ALPHATESTANDBLEND                   |
    */
   @ObservableComponent.field
-  transparencyMode?: number
+  transparencyMode?: number = -1
 
   /**
    * Does the albedo texture has alpha?

--- a/packages/decentraland-ecs/src/decentraland/Components.ts
+++ b/packages/decentraland-ecs/src/decentraland/Components.ts
@@ -672,16 +672,16 @@ export class Material extends ObservableComponent {
    * Sets the transparency mode of the material.
    * Defaults to -1.
    *
-   * | Value | Type                                |
-   * | ----- | ----------------------------------- |
-   * | -1    | AUTO  (Let the engine decide)       |
-   * | 0     | OPAQUE  (default)                   |
-   * | 1     | ALPHATEST                           |
-   * | 2     | ALPHABLEND                          |
-   * | 3     | ALPHATESTANDBLEND                   |
+   * | Value | Type                                           |
+   * | ----- | ---------------------------------------------- |
+   * | 0     | OPAQUE  (default)                              |
+   * | 1     | ALPHATEST                                      |
+   * | 2     | ALPHABLEND                                     |
+   * | 3     | ALPHATESTANDBLEND                              |
+   * | 4     | AUTO (ALPHABLEND if alpha OPAQUE otherwise     |
    */
   @ObservableComponent.field
-  transparencyMode?: number = -1
+  transparencyMode: number = 4
 
   /**
    * Does the albedo texture has alpha?

--- a/packages/engine/components/disposableComponents/PBRMaterial.ts
+++ b/packages/engine/components/disposableComponents/PBRMaterial.ts
@@ -28,7 +28,7 @@ const defaults = {
   bumpTexture: '',
   refractionTexture: '',
   disableLighting: false,
-  transparencyMode: -1,
+  transparencyMode: 4,
   hasAlpha: false
 }
 
@@ -101,7 +101,7 @@ export class PBRMaterial extends DisposableComponent {
     }
 
     if ('transparencyMode' in data) {
-      if (data.transparencyMode === -1) {
+      if (data.transparencyMode === 4) {
         m.transparencyMode = null
       } else {
         m.transparencyMode = Math.min(3, Math.max(0, validators.int(data.transparencyMode, defaults.transparencyMode)))

--- a/packages/engine/components/disposableComponents/PBRMaterial.ts
+++ b/packages/engine/components/disposableComponents/PBRMaterial.ts
@@ -28,7 +28,7 @@ const defaults = {
   bumpTexture: '',
   refractionTexture: '',
   disableLighting: false,
-  transparencyMode: 0,
+  transparencyMode: -1,
   hasAlpha: false
 }
 
@@ -101,7 +101,12 @@ export class PBRMaterial extends DisposableComponent {
     }
 
     if ('transparencyMode' in data) {
-      m.transparencyMode = Math.min(3, Math.max(0, validators.int(data.transparencyMode, defaults.transparencyMode)))
+      if(data.transparencyMode == -1){
+        m.transparencyMode = null;
+      }
+      else{
+        m.transparencyMode = Math.min(3, Math.max(0, validators.int(data.transparencyMode, defaults.transparencyMode)))
+      }
     }
 
     if ('emissiveIntensity' in data) {

--- a/packages/engine/components/disposableComponents/PBRMaterial.ts
+++ b/packages/engine/components/disposableComponents/PBRMaterial.ts
@@ -101,8 +101,8 @@ export class PBRMaterial extends DisposableComponent {
     }
 
     if ('transparencyMode' in data) {
-      if (data.transparencyMode == -1) {
-        m.transparencyMode = null;
+      if (data.transparencyMode === -1) {
+        m.transparencyMode = null
       } else {
         m.transparencyMode = Math.min(3, Math.max(0, validators.int(data.transparencyMode, defaults.transparencyMode)))
       }

--- a/packages/engine/components/disposableComponents/PBRMaterial.ts
+++ b/packages/engine/components/disposableComponents/PBRMaterial.ts
@@ -101,10 +101,9 @@ export class PBRMaterial extends DisposableComponent {
     }
 
     if ('transparencyMode' in data) {
-      if(data.transparencyMode == -1){
+      if (data.transparencyMode == -1) {
         m.transparencyMode = null;
-      }
-      else{
+      } else {
         m.transparencyMode = Math.min(3, Math.max(0, validators.int(data.transparencyMode, defaults.transparencyMode)))
       }
     }


### PR DESCRIPTION
https://github.com/decentraland/unity-client/issues/406

# What? <!-- what is this PR? -->
Add an AUTO (-1) value to transparencyMode as default

# Why? <!-- Explain the reason -->
Babylon uses transparencyMode = null to auto set the rendering mode. Adding a -1 value to explicitily allow the enginge to decide what to use.
