### PR TITLE
fix: onEnter should maximize the chat and not toggle it

### DIFF
--- a/packages/ui/avatar/chatWindow.ts
+++ b/packages/ui/avatar/chatWindow.ts
@@ -251,7 +251,7 @@ function initializeMinimizedChat(parent: UIFullScreen) {
   minimizedIcon.vAlign = 'top'
   minimizedIcon.isPointerBlocker = true
   minimizedIcon.onClick = new OnClick(toggleChat)
-  minimizedIcon.onEnter = new OnEnter(toggleChat)
+  minimizedIcon.onEnter = new OnEnter(() => setMaximized(true))
 
   return containerMinimized
 }


### PR DESCRIPTION
# What? <!-- what is this PR? -->
...

# Why? <!-- Explain the reason -->
OnEnter should maximize the chat and not toggle it
