### PR TITLE
feat: allow parenting to null

### DIFF
--- a/packages/decentraland-ecs/src/decentraland/Implementation.ts
+++ b/packages/decentraland-ecs/src/decentraland/Implementation.ts
@@ -13,6 +13,9 @@ import {
 
 import { DecentralandInterface } from './Types'
 
+// This number is defined in the protocol ECS.SetEntityParent.3
+const ROOT_ENTITY_ID = '0'
+
 export class DecentralandSynchronizationSystem implements ISystem {
   cachedComponents: Record<string, Record<string, string>> = {}
   engine!: Engine
@@ -211,6 +214,6 @@ export class DecentralandSynchronizationSystem implements ISystem {
    * This method is called when a parent changes in an entity.
    */
   private parentChanged(event: ParentChanged) {
-    this.dcl.setParent(event.entity.uuid, event.parent.uuid)
+    this.dcl.setParent(event.entity.uuid, event.parent ? event.parent.uuid : ROOT_ENTITY_ID)
   }
 }

--- a/packages/decentraland-ecs/src/ecs/Entity.ts
+++ b/packages/decentraland-ecs/src/ecs/Entity.ts
@@ -281,7 +281,7 @@ export class Entity implements IEntity {
   /**
    * Sets the parent entity
    */
-  setParent(newParent: IEntity): IEntity {
+  setParent(newParent: IEntity | null): IEntity {
     let parent = !newParent && this.engine ? this.engine.rootEntity : newParent
     let currentParent = this.getParent()
 
@@ -309,7 +309,7 @@ export class Entity implements IEntity {
       delete currentParent.children[this.uuid]
     }
 
-    if (newParent.uuid !== '0') {
+    if (newParent !== null && newParent.uuid !== '0') {
       if (!newParent.isAddedToEngine() && this.isAddedToEngine()) {
         // tslint:disable-next-line:semicolon
         ;(this.engine as IEngine).removeEntity(this)
@@ -324,7 +324,7 @@ export class Entity implements IEntity {
     this.registerAsChild()
 
     if (this.eventManager && this.engine) {
-      this.eventManager.fireEvent(new ParentChanged(this as IEntity, parent))
+      this.eventManager.fireEvent(new ParentChanged(this as IEntity, parent!))
     }
 
     return this

--- a/packages/decentraland-ecs/src/ecs/Entity.ts
+++ b/packages/decentraland-ecs/src/ecs/Entity.ts
@@ -281,8 +281,8 @@ export class Entity implements IEntity {
   /**
    * Sets the parent entity
    */
-  setParent(newParent: IEntity | null): IEntity {
-    let parent = !newParent && this.engine ? this.engine.rootEntity : newParent
+  setParent(_parent: IEntity | null): IEntity {
+    let newParent = !_parent && this.engine ? this.engine.rootEntity : _parent
     let currentParent = this.getParent()
 
     if (newParent === this) {
@@ -320,11 +320,11 @@ export class Entity implements IEntity {
       }
     }
 
-    this._parent = parent || null
+    this._parent = newParent || null
     this.registerAsChild()
 
     if (this.eventManager && this.engine) {
-      this.eventManager.fireEvent(new ParentChanged(this as IEntity, parent!))
+      this.eventManager.fireEvent(new ParentChanged(this as IEntity, newParent))
     }
 
     return this

--- a/packages/decentraland-ecs/src/ecs/IEntity.ts
+++ b/packages/decentraland-ecs/src/ecs/IEntity.ts
@@ -104,7 +104,7 @@ export class ComponentAdded {
  */
 @EventConstructor()
 export class ParentChanged {
-  constructor(public entity: IEntity, public parent: IEntity) {
+  constructor(public entity: IEntity, public parent: IEntity | null) {
     // stub
   }
 }

--- a/test/unit/ecs.test.tsx
+++ b/test/unit/ecs.test.tsx
@@ -560,14 +560,67 @@ describe('ECS', () => {
     })
 
     it('should correctly set parent entities', () => {
-      const ent1 = new Entity()
-      const ent2 = new Entity()
-      ent1.setParent(ent2)
-      engine.addEntity(ent1)
-      engine.addEntity(ent2)
+      const child = new Entity()
+      const parent = new Entity()
+      child.setParent(parent)
 
-      expect(ent1.getParent()).to.eq(ent2)
-      expect(Object.keys(ent2.children).some(c => c === ent1.uuid)).to.eq(true)
+      expect(parent.isAddedToEngine()).to.eq(false)
+      expect(child.isAddedToEngine()).to.eq(false)
+
+      engine.addEntity(parent)
+
+      expect(child.isAddedToEngine()).to.eq(true)
+      expect(parent.isAddedToEngine()).to.eq(true)
+
+      expect(child.getParent()).to.eq(parent)
+      expect(Object.keys(parent.children).some(c => c === child.uuid)).to.eq(true)
+    })
+
+    it('should correctly set the rootEntity when setParent(null) is called AND the entity is added to the engine', () => {
+      const child = new Entity()
+      const parent = new Entity()
+      child.setParent(parent)
+
+      expect(parent.isAddedToEngine()).to.eq(false)
+      expect(child.isAddedToEngine()).to.eq(false)
+
+      expect(parent.getParent()).to.eq(null)
+      expect(child.getParent() === parent).to.eq(true, 'child.parent === parent')
+
+      engine.addEntity(parent)
+
+      expect(child.isAddedToEngine()).to.eq(true)
+      expect(parent.isAddedToEngine()).to.eq(true)
+
+      child.setParent(null)
+
+      expect(child.getParent() === engine.rootEntity).to.eq(true, 'child.parent === engine.rootEntity')
+      expect(Object.keys(parent.children).some(c => c === child.uuid)).to.eq(false)
+    })
+
+    it('should correctly set null when setParent(null) is called AND the entity is NOT added to the engine', () => {
+      const child = new Entity()
+      const parent = new Entity()
+      child.setParent(parent)
+
+      expect(parent.isAddedToEngine()).to.eq(false, 'parent is not added to the engine')
+      expect(child.isAddedToEngine()).to.eq(false, 'child is not added to the engine')
+
+      expect(parent.getParent()).to.eq(null)
+      expect(child.getParent() === parent).to.eq(true, 'child.parent === parent')
+
+      expect(Object.keys(parent.children).some(c => c === child.uuid)).to.eq(
+        true,
+        'parent must have the child in the children list'
+      )
+
+      child.setParent(null)
+
+      expect(child.getParent()).to.eq(null)
+      expect(Object.keys(parent.children).some(c => c === child.uuid)).to.eq(
+        false,
+        'parent must not have the child in the children list'
+      )
     })
 
     it('should set parents after adding entities to engine', () => {


### PR DESCRIPTION
Allows `entity.setParent(null)` using `engine.rootEntity` as default