### PR TITLE
feat: filter some events before segment

### DIFF
--- a/packages/shared/analytics.ts
+++ b/packages/shared/analytics.ts
@@ -5,6 +5,7 @@ import { Vector2, ReadOnlyVector3, Vector3 } from 'decentraland-ecs/src'
 
 import { chatObservable, ChatEvent } from './comms/chat'
 import { avatarMessageObservable } from './comms/peers'
+import { AvatarMessageType } from './comms/types'
 import { positionObservable } from './world/positionThings'
 
 declare var window: any
@@ -75,7 +76,13 @@ function hookObservables() {
     }
   })
 
-  avatarMessageObservable.add(({ type, ...data }) => queueTrackingEvent(type, data))
+  avatarMessageObservable.add(({ type, ...data }) => {
+    if (type === AvatarMessageType.USER_VISIBLE || type === AvatarMessageType.USER_POSE) {
+      return
+    }
+
+    queueTrackingEvent(type, data)
+  })
 
   let lastTime: number = performance.now()
   let seconds = 0


### PR DESCRIPTION
Regarding to a talk with @dnul there are too many USER_VISIBLE and USER_POSE messages, it's preferred to filter them until a new approach of knowing how and when to send them