### PR TITLE
Setting aws keys correctly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,9 +97,9 @@ jobs:
             - build-{{ .Revision }}
       - run: sudo apt-get -y -qq install awscli
       - run:
-          name: Export DEV/STG AWS Keys
+          name: Configure DEV/STG AWS Keys
           command: |
-            export AWS_ACCESS_KEY_ID={AWS_DEV_ACCESS_KEY_ID} && export AWS_SECRET_ACCESS_KEY={AWS_DEV_SECRET_ACCESS_KEY}
+            aws configure set aws_access_key_id ${AWS_DEV_ACCESS_KEY_ID} && aws configure set aws_secret_access_key ${AWS_DEV_SECRET_ACCESS_KEY}
       - run:
           name: Deploy to S3 (.zone) under subfolder if tests pass and branch is not master
           command: aws s3 sync static s3://explorer.decentraland.zone/branch/${CIRCLE_BRANCH} --acl public-read

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
       - run:
           name: Export DEV/STG AWS Keys
           command: |
-            export AWS_ACCESS_KEY_ID=${AWS_DEV_ACCESS_KEY_ID} && export AWS_SECRET_ACCESS_KEY=${AWS_DEV_SECRET_ACCESS_KEY}
+            export AWS_ACCESS_KEY_ID={AWS_DEV_ACCESS_KEY_ID} && export AWS_SECRET_ACCESS_KEY={AWS_DEV_SECRET_ACCESS_KEY}
       - run:
           name: Deploy to S3 (.zone) under subfolder if tests pass and branch is not master
           command: aws s3 sync static s3://explorer.decentraland.zone/branch/${CIRCLE_BRANCH} --acl public-read
@@ -117,9 +117,9 @@ jobs:
             - build-{{ .Revision }}
       - run: sudo apt-get -y -qq install awscli
       - run:
-          name: Export DEV/STG AWS Keys
+          name: Configure DEV/STG AWS Keys
           command: |
-            export AWS_ACCESS_KEY_ID=${AWS_DEV_ACCESS_KEY_ID} && export AWS_SECRET_ACCESS_KEY=${AWS_DEV_SECRET_ACCESS_KEY}
+            aws configure set aws_access_key_id ${AWS_DEV_ACCESS_KEY_ID} && aws configure set aws_secret_access_key ${AWS_DEV_SECRET_ACCESS_KEY}
       - run:
           name: Deploy to S3 (.zone) if tests pass and branch is master
           command: aws s3 sync static s3://explorer.decentraland.zone/ --acl public-read
@@ -137,9 +137,9 @@ jobs:
             - build-{{ .Revision }}
       - run: sudo apt-get -y -qq install awscli
       - run:
-          name: Export DEV/STG AWS Keys
+          name: Configure DEV/STG AWS Keys
           command: |
-            export AWS_ACCESS_KEY_ID=${AWS_DEV_ACCESS_KEY_ID} && export AWS_SECRET_ACCESS_KEY=${AWS_DEV_SECRET_ACCESS_KEY}
+            aws configure set aws_access_key_id ${AWS_DEV_ACCESS_KEY_ID} && aws configure set aws_secret_access_key ${AWS_DEV_SECRET_ACCESS_KEY}
       - run:
           name: Deploy tag to .today/tags/${CIRCLE_TAG}
           command: |
@@ -162,9 +162,9 @@ jobs:
             - build-{{ .Revision }}
       - run: sudo apt-get -y -qq install awscli
       - run:
-          name: Export PRD AWS Keys
+          name: Configure PRD AWS Keys
           command: |
-            export AWS_ACCESS_KEY_ID=${AWS_PRD_ACCESS_KEY_ID} && export AWS_SECRET_ACCESS_KEY=${AWS_PRD_SECRET_ACCESS_KEY}
+            aws configure set aws_access_key_id ${AWS_PRD_ACCESS_KEY_ID} && aws configure set aws_secret_access_key ${AWS_PRD_SECRET_ACCESS_KEY}
       - run:
           name: Deploy tag to .org/tags/${CIRCLE_TAG}
           command: |


### PR DESCRIPTION
Fixing incorrect export of AWS keys (because when you run `EXPORT` on different `commands` circle does it in different shells, now setting it up on aws config directly).