### PR TITLE
fix: change DEBUG url param to DEBUG_MODE

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ To start hacking, run:
 
 To run the client in `debug` mode append the following query parameter to the URL:
 
-    http://localhost:8080/?DEBUG
+    http://localhost:8080/?DEBUG_MODE
 
 To run the client in first person perspective append the following query parameter to the URL:
 
-    http://localhost:8080/?DEBUG&fps
+    http://localhost:8080/?DEBUG_MODE&fps
 
 To spawn in a specific set of coordinates append the following query paramter:
 
-    http://localhost:8080/?DEBUG&fps&position=10,10
+    http://localhost:8080/?DEBUG_MODE&fps&position=10,10
 
 ## Running tests
 

--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -84,7 +84,7 @@ export const EDITOR: boolean = !!(global as any).isEditor
 
 // Development
 export const AVOID_WEB3: boolean = !!(global as any).avoidWeb3 || EDITOR
-export const DEBUG = location.search.indexOf('DEBUG') !== -1 || !!(global as any).mocha || PREVIEW || EDITOR
+export const DEBUG = location.search.indexOf('DEBUG_MODE') !== -1 || !!(global as any).mocha || PREVIEW || EDITOR
 export const USE_LOCAL_COMMS = location.search.indexOf('LOCAL_COMMS') !== -1 || PREVIEW
 export const DEBUG_ANALYTICS = location.search.indexOf('DEBUG_ANALYTICS') !== -1
 export const DEBUG_MOBILE = location.search.indexOf('DEBUG_MOBILE') !== -1


### PR DESCRIPTION
# Why? <!-- Explain the reason -->
Since we are using `location.indexOf` to know is a configuration flag is present or not whenever developers use any `DEBUG_*` also `DEBUG` mode is being enabled. The PR changes the url param name until new config approach is set (maybe something like CRA via `.env`)