### PR TITLE
fix: ignore warning readding entities to the engine

### DIFF
--- a/packages/decentraland-ecs/src/ecs/Engine.ts
+++ b/packages/decentraland-ecs/src/ecs/Engine.ts
@@ -75,8 +75,8 @@ export class Engine implements IEngine {
     if (!parent) {
       entity.setParent(this.rootEntity)
     } else {
-      if (!parent.isAddedToEngine()) {
-        log('Engine: warning, added an entity with a parent not present in the engine')
+      if (!parent.isAddedToEngine() && parent !== this.rootEntity) {
+        log('Engine: warning, added an entity with a parent not present in the engine. Parent id: ' + parent.uuid)
       }
     }
 

--- a/packages/decentraland-ecs/src/ecs/Entity.ts
+++ b/packages/decentraland-ecs/src/ecs/Entity.ts
@@ -271,7 +271,7 @@ export class Entity implements IEntity {
    * Returns false if no engine was defined.
    */
   isAddedToEngine(): boolean {
-    if (this.engine && this.uuid in this.engine.entities) {
+    if (this.engine && (this.uuid in this.engine.entities || this.engine.rootEntity === this)) {
       return true
     }
 

--- a/test/unit/ecs.test.tsx
+++ b/test/unit/ecs.test.tsx
@@ -576,6 +576,17 @@ describe('ECS', () => {
       expect(Object.keys(parent.children).some(c => c === child.uuid)).to.eq(true)
     })
 
+    it('should be able to re-add an entity to the engine', () => {
+      const ent = new Entity()
+      expect(ent.isAddedToEngine()).to.eq(false)
+      engine.addEntity(ent)
+      expect(ent.isAddedToEngine()).to.eq(true)
+      engine.removeEntity(ent)
+      expect(ent.isAddedToEngine()).to.eq(false)
+      engine.addEntity(ent)
+      expect(ent.isAddedToEngine()).to.eq(true)
+    })
+
     it('should correctly set the rootEntity when setParent(null) is called AND the entity is added to the engine', () => {
       const child = new Entity()
       const parent = new Entity()


### PR DESCRIPTION
closes https://github.com/decentraland/unity-client/issues/525