### PR TITLE
fix: audio should not be playing by default

### DIFF
--- a/packages/decentraland-ecs/src/decentraland/Audio.ts
+++ b/packages/decentraland-ecs/src/decentraland/Audio.ts
@@ -57,7 +57,7 @@ export class AudioSource extends ObservableComponent {
    * Is this AudioSource playing?
    */
   @ObservableComponent.field
-  playing: boolean = true
+  playing: boolean = false
 
   /**
    * Pitch, default: 1.0, range from 0.0 to MaxFloat


### PR DESCRIPTION
https://github.com/decentraland/unity-client/issues/407

# What? <!-- what is this PR? -->
Playing is now set to false by default

# Why? <!-- Explain the reason -->
Users found inconsistent that the sound was being played as soon as it was added to the component.
