### PR TITLE
chore: merge loading screens

### DIFF
--- a/static/unity/Build/DCLUnityLoader.js
+++ b/static/unity/Build/DCLUnityLoader.js
@@ -5134,7 +5134,7 @@ var UnityLoader = UnityLoader || {
           n = e.Module.progressLogoUrl ? e.Module.resolveBuildUrl(e.Module.progressLogoUrl) : r.progressLogoUrl,
           // o = e.Module.progressEmptyUrl ? e.Module.resolveBuildUrl(e.Module.progressEmptyUrl) : r.progressEmptyUrl,
           // a = e.Module.progressFullUrl ? e.Module.resolveBuildUrl(e.Module.progressFullUrl) : r.progressFullUrl,
-          currentProgress = 100 * t + '%',
+          currentProgress = 50 * t + '%',
           i =
             'position: absolute; left: 50%; top: 50%; -webkit-transform: translate(-50%, -50%); transform: translate(-50%, -50%);'
         e.logo ||

--- a/static/unity/Build/unity.data.unityweb
+++ b/static/unity/Build/unity.data.unityweb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0aab968e2c91a6872212051c786fc263cfe2ac1191a4fd974329f3c1eb1b43e1
-size 5207220
+oid sha256:7c1911ee7783cfdbc6f3bcd4a00507b476f78f6ca2ece80874de53d1b52ae095
+size 5210665

--- a/static/unity/Build/unity.wasm.code.unityweb
+++ b/static/unity/Build/unity.wasm.code.unityweb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a5db724fa41ddac5b2ca5addcafcd34eaa722d4f42f18ac4f53d9d01b39a12b2
-size 4804869
+oid sha256:68965caaf270313ad2bb3bd752433445996fbf0d1706d731dd4f14781a9d8af0
+size 4809334


### PR DESCRIPTION
https://github.com/decentraland/unity-client/issues/548

# What? <!-- what is this PR? -->
...

# Why? <!-- Explain the reason -->
Currently we have 3 loading screens. Merging the 2nd and 3rd one will make the waiting less frustrating.
