### PR TITLE
fix: default avatar textures

### DIFF
--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -97,7 +97,7 @@ export async function initShared(container: HTMLElement): Promise<ETHEREUM_NETWO
   const response = await fetchProfile()
   if (!response.ok) {
     defaultLogger.info(`Non existing profile, creating a random one`)
-    const avatar = await generateRandomAvatarSpec(userId)
+    const avatar = await generateRandomAvatarSpec()
     try {
       const creationResponse = await createProfile(avatar)
       defaultLogger.info(`New profile created with response ${creationResponse.status}`)


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Introduces a set of default textures that are mandatory for each avatar body type and that may not come in the `avatar.json` description. This comprises the eyes, eyebrows and mouth textures.

# Why? <!-- Explain the reason -->
This fix makes our random profile generation compatible with the current spec of presets that right now might not describe a certain texture and thus are not be rendered properly in explorer.