### PR TITLE
fix: match avatar contents to presets and catalog

### DIFF
--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -167,7 +167,7 @@ export function getServerConfigurations() {
     profile: `https://profile.decentraland.${TLDDefault}/api/v1`,
     avatar: {
       catalog: 'https://avatar-assets.now.sh',
-      contents: `https://s3.amazonaws.com/content-service.decentraland.${TLDDefault}/`,
+      contents: `https://s3.amazonaws.com/content-service.decentraland.org/`,
       presets: `https://s3.amazonaws.com/avatars-storage.decentraland.org/mobile-avatars`
     },
     darApi:


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Match avatar contents S3 bucket to use `org` as well as the avatar catalog and presets.

# Why? <!-- Explain the reason -->
This way we ensure that the contents are matched and avoid content not found. Using `org` as it is the only source of truth for all these assets nowadays.
