### PR TITLE
feat: lifecycle changes

### DIFF
--- a/packages/decentraland-ecs/src/decentraland/Types.ts
+++ b/packages/decentraland-ecs/src/decentraland/Types.ts
@@ -246,9 +246,9 @@ export interface IEvents {
   }
 
   /**
-   * This is triggered once the scene is ready to start.
+   * This is triggered once the scene should start.
    */
-  sceneReady: {}
+  sceneStart: {}
 
   /**
    * After checking entities outside the fences, if any is outside, this event

--- a/packages/decentraland-ecs/src/decentraland/Types.ts
+++ b/packages/decentraland-ecs/src/decentraland/Types.ts
@@ -246,6 +246,11 @@ export interface IEvents {
   }
 
   /**
+   * This is triggered once the scene is ready to start.
+   */
+  sceneReady: {}
+
+  /**
    * After checking entities outside the fences, if any is outside, this event
    * will be triggered with all the entities outside the scene.
    */

--- a/packages/decentraland-loader/lifecycle/controllers/parcel.ts
+++ b/packages/decentraland-loader/lifecycle/controllers/parcel.ts
@@ -29,17 +29,20 @@ export class ParcelLifeCycleController extends EventEmitter {
     this.currentPosition = position
 
     this.isTargetPlaced = true
-    const sightedParcels = parcelsInScope(this.config, position)
+    const sightedParcels = parcelsInScope(this.config.lineOfSightRadius, position)
     const sightedParcelsSet = new Set<string>()
-    for (const parcel of sightedParcels) {
+
+    const newlySightedParcels = sightedParcels.filter(parcel => {
       sightedParcelsSet.add(parcel)
-      this.parcelSighted(parcel)
-    }
-    for (const parcel of this.currentlySightedParcels) {
-      if (!sightedParcelsSet.has(parcel)) {
-        this.switchParcelToOutOfSight(parcel)
-      }
-    }
+      return this.parcelSighted(parcel)
+    })
+    this.emit('Sighted', newlySightedParcels)
+
+    const newlyOOSParcels = [...this.currentlySightedParcels]
+      .filter(parcel => !sightedParcelsSet.has(parcel))
+      .filter(parcel => this.switchParcelToOutOfSight(parcel))
+    this.emit('Lost sight', newlyOOSParcels)
+
     this.currentlySightedParcels = sightedParcelsSet
   }
 
@@ -47,27 +50,45 @@ export class ParcelLifeCycleController extends EventEmitter {
     return !!this.currentlySightedParcels.has(parcel)
   }
 
-  parcelSighted(parcel: string) {
-    let status = this.parcelStatus.get(parcel)
+  /**
+   * Returns true if newly sighted, false otherwise
+   *
+   * @param parcel Parcel string position
+   */
+  parcelSighted(parcel: string): boolean {
+    let status = this.getParcelStatus(parcel)
+    if (status.isOutOfSight()) {
+      this.currentlySightedParcels.add(parcel)
+      status.setInSight()
+      return true
+    }
+    return false
+  }
+
+  getParcelStatus(parcel: string) {
+    let status
+    this.parcelStatus.get(parcel)
     if (!status) {
       status = new ParcelLifeCycleStatus(parcel)
       this.parcelStatus.set(parcel, status)
     }
-    if (status.isOutOfSight()) {
-      this.currentlySightedParcels.add(parcel)
-      status.setInSight()
-      this.emit('Sighted', parcel)
-    }
+    return status
   }
 
+  /**
+   * Returns true if newly switched to out of sight, false otherwise
+   *
+   * @param parcel Parcel position string
+   */
   switchParcelToOutOfSight(parcel: string) {
     if (!this.parcelStatus.has(parcel)) {
-      return
+      return false
     }
     const status = this.parcelStatus.get(parcel)
     if (status && status.isInSight()) {
       status.setOffSight()
-      this.emit('Lost sight', parcel)
+      return true
     }
+    return false
   }
 }

--- a/packages/decentraland-loader/lifecycle/controllers/position.ts
+++ b/packages/decentraland-loader/lifecycle/controllers/position.ts
@@ -5,6 +5,7 @@ import { ParcelLifeCycleController } from './parcel'
 
 export class PositionLifecycleController extends EventEmitter {
   private positionSettled: boolean = false
+  private currentSceneId?: string
   private currentlySightedScenes: string[] = []
 
   constructor(public parcelController: ParcelLifeCycleController, public sceneController: SceneLifeCycleController) {
@@ -14,6 +15,8 @@ export class PositionLifecycleController extends EventEmitter {
 
   async reportCurrentPosition(position: Vector2Component, teleported: boolean) {
     const { sighted, lostSight } = this.parcelController.reportCurrentPosition(position)
+
+    this.currentSceneId = await this.sceneController.requestSceneId(`${position.x},${position.y}`)
 
     if (sighted) {
       const newlySightedScenes = await this.sceneController.onSight(sighted)
@@ -46,7 +49,7 @@ export class PositionLifecycleController extends EventEmitter {
 
       if (settling) {
         this.positionSettled = settling
-        this.emit('Settled Position')
+        this.emit('Settled Position', this.currentSceneId)
       }
     }
   }

--- a/packages/decentraland-loader/lifecycle/controllers/position.ts
+++ b/packages/decentraland-loader/lifecycle/controllers/position.ts
@@ -24,6 +24,7 @@ export class PositionLifecycleController extends EventEmitter {
     }
   }
 
+  // TODO - this will come through the SceneReady events from the engine - moliva - 12/08/2019
   reportSceneStarted(scene: SceneLifeCycleStatus) {
     if (!this.isSettled && this.sceneController.contains(scene, this.currentPosition!)) {
       this.isSettled = true

--- a/packages/decentraland-loader/lifecycle/controllers/position.ts
+++ b/packages/decentraland-loader/lifecycle/controllers/position.ts
@@ -1,34 +1,53 @@
 import { Vector2Component } from 'atomicHelpers/landHelpers'
 import { SceneLifeCycleController } from './scene'
 import { EventEmitter } from 'events'
-import { SceneLifeCycleStatus } from '../lib/scene.status'
+import { ParcelLifeCycleController } from './parcel'
 
 export class PositionLifecycleController extends EventEmitter {
-  currentPosition?: Vector2Component
-  isSettled: boolean = false
+  private positionSettled: boolean = false
+  private currentlySightedScenes: string[] = []
 
-  constructor(public sceneController: SceneLifeCycleController) {
+  constructor(public parcelController: ParcelLifeCycleController, public sceneController: SceneLifeCycleController) {
     super()
+    sceneController.on('Scene ready', () => this.checkPositionSettlement())
   }
 
-  reportCurrentPosition(position: Vector2Component) {
-    if (this.currentPosition && this.currentPosition.x === position.x && this.currentPosition.y === position.y) {
-      return
+  async reportCurrentPosition(position: Vector2Component, teleported: boolean) {
+    const { sighted, lostSight } = this.parcelController.reportCurrentPosition(position)
+
+    if (sighted) {
+      const newlySightedScenes = await this.sceneController.onSight(sighted)
+
+      if (!this.eqSet(this.currentlySightedScenes, newlySightedScenes)) {
+        this.currentlySightedScenes = newlySightedScenes
+      }
     }
-    this.currentPosition = position
-    const currentPosStr = `${position.x},${position.y}`
-    if (this.isSettled && !this.sceneController.hasStarted(currentPosStr)) {
-      // Teleport
-      this.isSettled = false
-      this.emit('Unsettled Position', currentPosStr)
+    if (lostSight) {
+      this.sceneController.lostSight(lostSight)
     }
+
+    if (teleported) {
+      this.positionSettled = false
+      this.emit('Unsettled Position')
+    }
+
+    this.checkPositionSettlement()
   }
 
-  // TODO - this will come through the SceneReady events from the engine - moliva - 12/08/2019
-  reportSceneStarted(scene: SceneLifeCycleStatus) {
-    if (!this.isSettled && this.sceneController.contains(scene, this.currentPosition!)) {
-      this.isSettled = true
-      this.emit('Settled Position')
+  private eqSet(as: Array<any>, bs: Array<any>) {
+    if (as.length !== bs.length) return false
+    for (const a of as) if (!bs.includes(a)) return false
+    return true
+  }
+
+  private checkPositionSettlement() {
+    if (!this.positionSettled) {
+      const settling = this.currentlySightedScenes.every($ => this.sceneController.isReady($))
+
+      if (settling) {
+        this.positionSettled = settling
+        this.emit('Settled Position')
+      }
     }
   }
 }

--- a/packages/decentraland-loader/lifecycle/controllers/scene.ts
+++ b/packages/decentraland-loader/lifecycle/controllers/scene.ts
@@ -1,17 +1,27 @@
-import { SceneLifeCycleStatus } from '../lib/scene.status'
+import { SceneLifeCycleStatus, SceneLifeCycleStatusType } from '../lib/scene.status'
 import { Vector2Component } from 'atomicHelpers/landHelpers'
 import future, { IFuture } from 'fp-future'
 import { EventEmitter } from 'events'
 import { SceneDataDownloadManager } from './download'
+import { Observable } from 'decentraland-ecs/src/ecs/Observable'
+import defaultLogger from 'shared/logger'
+
+export type SceneLifeCycleStatusReport = { sceneId: string; status: SceneLifeCycleStatusType }
+
+export const sceneLifeCycleObservable = new Observable<Readonly<SceneLifeCycleStatusReport>>()
+
+type SceneId = string
 
 export class SceneLifeCycleController extends EventEmitter {
   private downloadManager: SceneDataDownloadManager
 
-  private _positionToSceneId = new Map<string, string | undefined>()
-  private futureOfPositionToSceneId = new Map<string, IFuture<string | undefined>>()
-  private sceneStatus = new Map<string, SceneLifeCycleStatus>()
+  private _positionToSceneId = new Map<string, SceneId | undefined>()
+  private futureOfPositionToSceneId = new Map<string, IFuture<SceneId | undefined>>()
+  private sceneStatus = new Map<SceneId, SceneLifeCycleStatus>()
 
-  private sceneParcelSightCount = new Map<string, number>()
+  private sceneParcelSightCount = new Map<SceneId, number>()
+
+  private currentlySightedScenes: SceneId[] = []
 
   constructor(opts: { downloadManager: SceneDataDownloadManager }) {
     super()
@@ -32,10 +42,41 @@ export class SceneLifeCycleController extends EventEmitter {
     )
   }
 
-  async onSight(position: string) {
-    let sceneId = await this.requestSceneId(position)
+  isReady(sceneId: SceneId): boolean {
+    const status = this.sceneStatus.get(sceneId)
+    return !!status && status.isReady()
+  }
 
-    if (sceneId) {
+  isPositionUnsettled() {
+    return true
+  }
+
+  distinct(value: any, index: number, self: Array<any>) {
+    return self.indexOf(value) === index
+  }
+
+  eqSet(as: Array<any>, bs: Array<any>) {
+    if (as.length !== bs.length) return false
+    for (const a of as) if (!bs.includes(a)) return false
+    return true
+  }
+
+  async onSight(positions: string[]) {
+    const positionSceneIds = (await Promise.all(
+      positions.map(position => this.requestSceneId(position).then(sceneId => ({ position, sceneId })))
+    )).filter(({ sceneId }) => sceneId !== undefined) as { position: string; sceneId: SceneId }[]
+
+    const newlySightedScenes = positionSceneIds.map($ => $.sceneId).filter(this.distinct)
+
+    if (this.eqSet(this.currentlySightedScenes, newlySightedScenes)) {
+      return
+    }
+
+    this.currentlySightedScenes = newlySightedScenes
+
+    this.checkSightedSceneStatus()
+
+    positionSceneIds.forEach(async ({ position, sceneId }) => {
       const previousSightCount = this.sceneParcelSightCount.get(sceneId) || 0
       this.sceneParcelSightCount.set(sceneId, previousSightCount + 1)
 
@@ -50,31 +91,51 @@ export class SceneLifeCycleController extends EventEmitter {
         this.emit('Preload scene', sceneId)
         this.sceneStatus.get(sceneId)!.status = 'awake'
       }
-    }
+    })
   }
-  async lostSight(position: string) {
-    let sceneId = await this.requestSceneId(position)
-    if (!sceneId) {
-      return
-    }
-    const previousSightCount = this.sceneParcelSightCount.get(sceneId) || 0
-    const newSightCount = previousSightCount - 1
-    this.sceneParcelSightCount.set(sceneId, newSightCount)
 
-    if (newSightCount <= 0) {
-      const sceneStatus = this.sceneStatus.get(sceneId)
-      if (sceneStatus && sceneStatus.isAwake()) {
-        sceneStatus.status = 'unloaded'
-        this.emit('Unload scene', sceneId)
+  checkSightedSceneStatus() {
+    const shouldShowLoadingScreen =
+      this.isPositionUnsettled() && this.currentlySightedScenes.some($ => !this.isReady($))
+    this.emit('LoadingScreen setVisible', shouldShowLoadingScreen)
+  }
+
+  lostSight(positions: string[]) {
+    positions.forEach(async position => {
+      let sceneId = await this.requestSceneId(position)
+      if (!sceneId) {
+        return
       }
-    }
+      const previousSightCount = this.sceneParcelSightCount.get(sceneId) || 0
+      const newSightCount = previousSightCount - 1
+      this.sceneParcelSightCount.set(sceneId, newSightCount)
+
+      if (newSightCount <= 0) {
+        const sceneStatus = this.sceneStatus.get(sceneId)
+        if (sceneStatus && sceneStatus.isAwake()) {
+          sceneStatus.status = 'unloaded'
+          this.emit('Unload scene', sceneId)
+        }
+      }
+    })
   }
 
   reportDataLoaded(sceneId: string) {
     if (this.sceneStatus.has(sceneId) && this.sceneStatus.get(sceneId)!.status === 'awake') {
-      this.sceneStatus.get(sceneId)!.status = 'ready'
+      this.sceneStatus.get(sceneId)!.status = 'loaded'
       this.emit('Start scene', sceneId)
     }
+  }
+
+  reportStatus(sceneId: string, status: SceneLifeCycleStatusType) {
+    const lifeCycleStatus = this.sceneStatus.get(sceneId)
+    if (!lifeCycleStatus) {
+      defaultLogger.info(`not lifecycle status for scene ${sceneId}`)
+      return
+    }
+    lifeCycleStatus.status = status
+
+    this.checkSightedSceneStatus()
   }
 
   async requestSceneId(position: string): Promise<string | undefined> {

--- a/packages/decentraland-loader/lifecycle/lib/scene.status.ts
+++ b/packages/decentraland-loader/lifecycle/lib/scene.status.ts
@@ -1,7 +1,9 @@
 import { ILand } from 'shared/types'
 
+export type SceneLifeCycleStatusType = 'unloaded' | 'awake' | 'loaded' | 'ready'
+
 export class SceneLifeCycleStatus {
-  status: 'unloaded' | 'awake' | 'ready' = 'unloaded'
+  status: SceneLifeCycleStatusType = 'unloaded'
 
   constructor(public sceneDescription: ILand) {}
 
@@ -13,7 +15,7 @@ export class SceneLifeCycleStatus {
     return this.status === 'unloaded'
   }
 
-  isRunning() {
+  isReady() {
     return this.status === 'ready'
   }
 }

--- a/packages/decentraland-loader/lifecycle/lib/scope.ts
+++ b/packages/decentraland-loader/lifecycle/lib/scope.ts
@@ -10,11 +10,11 @@ export function squareAndSum(a: number, b: number) {
 
 const cachedDeltas: Vector2Component[] = []
 
-export function parcelsInScope(config: ParcelConfigurationOptions, position: Vector2Component): string[] {
+export function parcelsInScope(lineOfSightRadius: number, position: Vector2Component): string[] {
   const result: string[] = []
   let length = cachedDeltas.length
   if (!length) {
-    calculateCachedDeltas(config)
+    calculateCachedDeltas(lineOfSightRadius)
     length = cachedDeltas.length
   }
   for (let i = 0; i < length; i++) {
@@ -23,8 +23,7 @@ export function parcelsInScope(config: ParcelConfigurationOptions, position: Vec
   return result
 }
 
-function calculateCachedDeltas(config: ParcelConfigurationOptions) {
-  const limit = config.lineOfSightRadius
+function calculateCachedDeltas(limit: number) {
   const squaredRadius = limit * limit
   for (let x = -limit; x <= limit; x++) {
     for (let y = -limit; y <= limit; y++) {

--- a/packages/decentraland-loader/lifecycle/worker.ts
+++ b/packages/decentraland-loader/lifecycle/worker.ts
@@ -41,8 +41,8 @@ let downloadManager: SceneDataDownloadManager
     parcelController.on('Sighted', (parcels: string[]) => connector.notify('Parcel.sighted', { parcels }))
     parcelController.on('Lost sight', (parcels: string[]) => connector.notify('Parcel.lostSight', { parcels }))
 
-    positionController.on('Settled Position', () => {
-      connector.notify('Position.settled')
+    positionController.on('Settled Position', (sceneId: string) => {
+      connector.notify('Position.settled', { sceneId })
     })
     positionController.on('Unsettled Position', () => {
       connector.notify('Position.unsettled')

--- a/packages/decentraland-loader/lifecycle/worker.ts
+++ b/packages/decentraland-loader/lifecycle/worker.ts
@@ -4,7 +4,7 @@
 import { WebWorkerTransport } from 'decentraland-rpc'
 import { Adapter } from './lib/adapter'
 import { ParcelLifeCycleController } from './controllers/parcel'
-import { SceneLifeCycleController } from './controllers/scene'
+import { SceneLifeCycleController, SceneLifeCycleStatusReport } from './controllers/scene'
 import { PositionLifecycleController } from './controllers/position'
 import { SceneDataDownloadManager } from './controllers/download'
 import { ILand } from 'shared/types'
@@ -26,10 +26,6 @@ let downloadManager: SceneDataDownloadManager
  * - 'Scene.shouldUnload' (sceneId: string)
  * - 'Scene.shouldPrefetch' (sceneId: string)
  *
- * And optionally (to show loading boxes):
- * - 'Parcel.sighted' (xy: string)
- * - 'Parcel.lostSight' (xy: string)
- *
  * Make sure the main thread reports:
  * - 'User.setPosition' { position: {x: number, y: number } }
  * - 'Scene.prefetchDone' { sceneId: string }
@@ -41,11 +37,11 @@ let downloadManager: SceneDataDownloadManager
     sceneController = new SceneLifeCycleController({ downloadManager })
     positionController = new PositionLifecycleController(sceneController)
 
-    parcelController.on('Sighted', (parcel: string) => sceneController.onSight(parcel))
-    parcelController.on('Lost sight', (parcel: string) => sceneController.lostSight(parcel))
+    parcelController.on('Sighted', (parcels: string[]) => sceneController.onSight(parcels))
+    parcelController.on('Lost sight', (parcels: string[]) => sceneController.lostSight(parcels))
 
-    parcelController.on('Sighted', (parcel: string) => connector.notify('Parcel.sighted', { parcel }))
-    parcelController.on('Lost sight', (parcel: string) => connector.notify('Parcel.lostSight', { parcel }))
+    parcelController.on('Sighted', (parcels: string[]) => connector.notify('Parcel.sighted', { parcels }))
+    parcelController.on('Lost sight', (parcels: string[]) => connector.notify('Parcel.lostSight', { parcels }))
 
     positionController.on('Settled Position', (sceneId: string) => {
       connector.notify('Position.settled', { sceneId })
@@ -64,6 +60,10 @@ let downloadManager: SceneDataDownloadManager
       connector.notify('Scene.shouldUnload', { sceneId })
     })
 
+    sceneController.on('LoadingScreen setVisible', show => {
+      connector.notify('LoadingScreen.setVisible', { show })
+    })
+
     connector.on('User.setPosition', (opt: { position: { x: number; y: number } }) => {
       parcelController.reportCurrentPosition(opt.position)
       positionController.reportCurrentPosition(opt.position)
@@ -77,6 +77,10 @@ let downloadManager: SceneDataDownloadManager
 
     connector.on('Scene.prefetchDone', (opt: { sceneId: string }) => {
       sceneController.reportDataLoaded(opt.sceneId)
+    })
+
+    connector.on('Scene.status', (data: SceneLifeCycleStatusReport) => {
+      sceneController.reportStatus(data.sceneId, data.status)
     })
   })
 }

--- a/packages/engine/dcl/WebGLScene.ts
+++ b/packages/engine/dcl/WebGLScene.ts
@@ -4,6 +4,7 @@ import { SharedSceneContext } from 'engine/entities/SharedSceneContext'
 import { defaultLogger, ILogger } from 'shared/logger'
 import { DevTools } from 'shared/apis/DevTools'
 import { IEvents, IEventNames } from 'decentraland-ecs/src/decentraland/Types'
+import { sceneLifeCycleObservable } from '../../decentraland-loader/lifecycle/controllers/scene'
 
 /**
  * The WebGLScene has the responsibility of communicating the SceneWorker with the SharedSceneContext
@@ -45,6 +46,9 @@ export class WebGLScene<T> implements ParcelSceneAPI {
         system.getAPIInstance(DevTools).logger = this.logger
       })
       .catch($ => this.logger.error('registerWorker', $))
+
+    // TODO - give time for babylon engine to finish loading - remove babylon engine altogether
+    setTimeout(() => sceneLifeCycleObservable.notifyObservers({ sceneId: this.data.sceneId, status: 'ready' }), 500)
   }
 
   dispose(): void {

--- a/packages/engine/entities/SharedSceneContext.ts
+++ b/packages/engine/entities/SharedSceneContext.ts
@@ -178,8 +178,8 @@ export class SharedSceneContext implements BABYLON.IDisposable {
     this.eventSubscriber.emit(event, data)
   }
 
-  /// #ECS.SceneStarted: This message is sent after the scene ends executing the initialization code. Before the render loop.
-  SceneStarted(payload: SceneStartedPayload) {
+  /// #ECS.InitMessagesFinished: This message is sent after the scene ends executing the initialization code. Before the render loop.
+  InitMessagesFinished(payload: SceneStartedPayload) {
     this.sceneStarted.resolve(payload)
   }
 

--- a/packages/engine/renderer/camera.ts
+++ b/packages/engine/renderer/camera.ts
@@ -116,7 +116,7 @@ teleportObservable.add((position: { x: number; y: number }) => {
   return teleportTo(position.x, position.y)
 })
 
-export async function teleportTo(x: number, y: number) {
+async function teleportTo(x: number, y: number) {
   if (
     !(
       parcelLimits.minLandCoordinateX <= x &&

--- a/packages/entryPoints/index.ts
+++ b/packages/entryPoints/index.ts
@@ -7,6 +7,7 @@ import { enableParcelSceneLoading } from '../shared/world/parcelSceneManager'
 import { WebGLParcelScene } from '../engine/dcl/WebGLParcelScene'
 import { enableMiniMap } from '../engine/dcl/widgets/minimap'
 import { getWorldSpawnpoint } from '../shared/world/positionThings'
+import { worldRunningObservable } from '../shared/world/worldState'
 
 document.body.classList.remove('dcl-loading')
 
@@ -19,6 +20,9 @@ async function loadClient() {
 
   await enableParcelSceneLoading({
     parcelSceneClass: WebGLParcelScene,
+    onPositionSettled: () => {
+      worldRunningObservable.notifyObservers(true)
+    },
     onSpawnpoint: initialLand => {
       const newPosition = getWorldSpawnpoint(initialLand)
       const result = new BABYLON.Vector3(newPosition.x, newPosition.y, newPosition.z)

--- a/packages/entryPoints/unity.ts
+++ b/packages/entryPoints/unity.ts
@@ -1,5 +1,8 @@
 import { initializeUnity } from '../unity-interface/initializer'
 import { startUnityParcelLoading } from '../unity-interface/dcl'
+import { lastPlayerPosition, teleportObservable } from '../shared/world/positionThings'
+import defaultLogger from '../shared/logger'
+import { worldToGrid } from '../atomicHelpers/parcelScenePositions'
 
 const container = document.getElementById('gameContainer')
 
@@ -8,6 +11,14 @@ if (!container) throw new Error('cannot find element #gameContainer')
 initializeUnity(container)
   .then(async _ => {
     await startUnityParcelLoading()
+
+    _.instancedJS
+      .then($ => {
+        const gridPosition = { x: 0, y: 0 }
+        worldToGrid(lastPlayerPosition, gridPosition)
+        teleportObservable.notifyObservers(gridPosition)
+      })
+      .catch(defaultLogger.error)
 
     document.body.classList.remove('dcl-loading')
   })

--- a/packages/scene-system/scene.system.ts
+++ b/packages/scene-system/scene.system.ts
@@ -379,7 +379,7 @@ export default class GamekitScene extends Script {
         }
       }
 
-      this.eventSubscriber.once('sceneReady', () => {
+      this.eventSubscriber.once('sceneStart', () => {
         if (!this.manualUpdate) {
           this.startLoop()
         }

--- a/packages/scene-system/scene.system.ts
+++ b/packages/scene-system/scene.system.ts
@@ -17,6 +17,7 @@ import { defaultLogger } from 'shared/logger'
 
 import { customEval, getES5Context } from './sdk/sandbox'
 import { DevToolsAdapter } from './sdk/DevToolsAdapter'
+import { ScriptingTransport, ILogOpts } from 'decentraland-rpc/src/common/json-rpc/types'
 
 // tslint:disable-next-line:whitespace
 type IEngineAPI = import('shared/apis/EngineAPI').IEngineAPI
@@ -73,6 +74,10 @@ export default class GamekitScene extends Script {
 
   didStart = false
   provider: any = null
+
+  constructor(transport: ScriptingTransport, opt?: ILogOpts) {
+    super(transport, opt)
+  }
 
   onError(error: Error) {
     if (this.devToolsAdapter) {
@@ -374,18 +379,28 @@ export default class GamekitScene extends Script {
         }
       }
 
+      this.eventSubscriber.once('sceneReady', () => {
+        if (!this.manualUpdate) {
+          this.startLoop()
+        }
+
+        this.onStartFunctions.forEach($ => {
+          try {
+            $()
+          } catch (e) {
+            this.onError(e)
+          }
+        })
+      })
+
       try {
         await customEval((source as any) as string, getES5Context({ dcl }))
 
         this.events.push({
-          type: 'SceneStarted',
+          type: 'InitMessagesFinished',
           tag: 'scene',
           payload: '{}'
         })
-
-        if (!this.manualUpdate) {
-          this.startLoop()
-        }
 
         this.onStartFunctions.push(() => {
           const engine: IEngineAPI = this.engine as any
@@ -396,17 +411,6 @@ export default class GamekitScene extends Script {
       }
 
       this.sendBatch()
-
-      setTimeout(() => {
-        this.onStartFunctions.forEach($ => {
-          try {
-            $()
-          } catch (e) {
-            that.onError(e)
-          }
-        })
-        // TODO: review this timeout
-      }, 5000)
     } catch (e) {
       this.onError(e)
       // unload should be triggered here

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -55,7 +55,7 @@ export type EntityActionType =
   | 'ComponentDisposed'
   | 'ComponentRemoved'
   | 'ComponentUpdated'
-  | 'SceneStarted'
+  | 'InitMessagesFinished'
 
 export type CreateEntityPayload = { id: string }
 

--- a/packages/shared/world/SceneWorker.ts
+++ b/packages/shared/world/SceneWorker.ts
@@ -140,14 +140,14 @@ export class SceneWorker {
   }
 
   private subscribeToWorldRunningEvents() {
-    this.worldRunningObserver = worldRunningObservable.addOnce(isRunning => {
+    this.worldRunningObserver = worldRunningObservable.add(isRunning => {
       this.sendSceneReadyIfNecessary()
     })
   }
 
   private subscribeToSceneLifeCycleEvents() {
     this.sceneLifeCycleObserver = sceneLifeCycleObservable.add(obj => {
-      if (this.parcelScene.data.sceneId === obj.sceneId) {
+      if (this.parcelScene.data.sceneId === obj.sceneId && obj.status === 'ready') {
         this.sceneReady = true
         sceneLifeCycleObservable.remove(this.sceneLifeCycleObserver)
         this.sendSceneReadyIfNecessary()
@@ -159,6 +159,7 @@ export class SceneWorker {
     if (!this.sceneStarted && isWorldRunning() && this.sceneReady) {
       this.sceneStarted = true
       this.engineAPI!.sendSubscriptionEvent('sceneStart', {})
+      worldRunningObservable.remove(this.worldRunningObserver)
     }
   }
 

--- a/packages/shared/world/SceneWorker.ts
+++ b/packages/shared/world/SceneWorker.ts
@@ -66,6 +66,9 @@ export class SceneWorker {
   constructor(public parcelScene: ParcelSceneAPI, transport?: ScriptingTransport) {
     parcelScene.registerWorker(this)
 
+    this.subscribeToSceneLifeCycleEvents()
+    this.subscribeToWorldRunningEvents()
+
     this.loadSystem(transport)
       .then($ => this.system.resolve($))
       .catch($ => this.system.reject($))
@@ -143,11 +146,12 @@ export class SceneWorker {
   }
 
   private subscribeToSceneLifeCycleEvents() {
-    this.sceneLifeCycleObserver = sceneLifeCycleObservable.addOnce(obj => {
+    this.sceneLifeCycleObserver = sceneLifeCycleObservable.add(obj => {
       if (this.parcelScene.data.sceneId === obj.sceneId) {
         this.sceneReady = true
+        sceneLifeCycleObservable.remove(this.sceneLifeCycleObserver)
+        this.sendSceneReadyIfNecessary()
       }
-      this.sendSceneReadyIfNecessary()
     })
   }
 
@@ -169,8 +173,6 @@ export class SceneWorker {
     system.enable()
 
     this.subscribeToPositionEvents()
-    this.subscribeToSceneLifeCycleEvents()
-    this.subscribeToWorldRunningEvents()
 
     return system
   }

--- a/packages/shared/world/parcelSceneManager.ts
+++ b/packages/shared/world/parcelSceneManager.ts
@@ -103,7 +103,8 @@ export async function enableParcelSceneLoading(options: EnableParcelSceneLoading
     }
   })
 
-  ret.on('Position.settled', () => {
+  ret.on('Position.settled', async (opt: { sceneId: string }) => {
+    // TODO - readd spawnpoint - moliva - 15/08/2019
     if (options.onPositionSettled) {
       options.onPositionSettled()
     }

--- a/packages/shared/world/parcelSceneManager.ts
+++ b/packages/shared/world/parcelSceneManager.ts
@@ -7,6 +7,7 @@ import { SceneWorker, ParcelSceneAPI } from './SceneWorker'
 import { LoadableParcelScene, EnvironmentData, ILand, ILandToLoadableParcelScene } from '../types'
 import { ScriptingTransport } from 'decentraland-rpc/lib/common/json-rpc/types'
 import { sceneLifeCycleObservable } from '../../decentraland-loader/lifecycle/controllers/scene'
+import { worldRunningObservable } from './worldState'
 
 export type EnableParcelSceneLoadingOptions = {
   parcelSceneClass: { new (x: EnvironmentData<LoadableParcelScene>): ParcelSceneAPI }
@@ -114,6 +115,7 @@ export async function enableParcelSceneLoading(options: EnableParcelSceneLoading
     if (options.onPositionUnsettled) {
       options.onPositionUnsettled()
     }
+    worldRunningObservable.notifyObservers(false)
   })
 
   teleportObservable.add((position: { x: number; y: number }) => {

--- a/packages/shared/world/worldState.ts
+++ b/packages/shared/world/worldState.ts
@@ -1,0 +1,13 @@
+import { Observable } from '../../decentraland-ecs/src/ecs/Observable'
+
+let worldRunning: boolean = false
+
+export const worldRunningObservable = new Observable<Readonly<boolean>>()
+
+worldRunningObservable.add(state => {
+  worldRunning = state
+})
+
+export function isWorldRunning(): boolean {
+  return worldRunning
+}

--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -229,9 +229,9 @@ export async function initializeEngine(_gameInstance: GameInstance) {
   gameInstance = _gameInstance
 
   setLoadingScreenVisible(true)
-  unityInterface.DeactivateRendering()
 
   unityInterface.SetPosition(lastPlayerPosition.x, lastPlayerPosition.y, lastPlayerPosition.z)
+  unityInterface.DeactivateRendering()
 
   if (DEBUG) {
     unityInterface.SetDebug()

--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -30,8 +30,7 @@ import {
   getSceneWorkerBySceneID,
   getParcelSceneID,
   stopParcelSceneWorker,
-  loadParcelScene,
-  worldRunningObservable
+  loadParcelScene
 } from '../shared/world/parcelSceneManager'
 import { SceneWorker, ParcelSceneAPI, hudWorkerUrl } from '../shared/world/SceneWorker'
 import { ensureUiApis } from '../shared/world/uiSceneInitializer'
@@ -43,6 +42,7 @@ import { chatObservable } from '../shared/comms/chat'
 import { queueTrackingEvent } from '../shared/analytics'
 import { getUserProfile } from '../shared/comms/peers'
 import { sceneLifeCycleObservable } from '../decentraland-loader/lifecycle/controllers/scene'
+import { worldRunningObservable } from '../shared/world/worldState'
 
 let gameInstance!: GameInstance
 

--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -41,6 +41,7 @@ import { DEBUG, ENGINE_DEBUG_PANEL, SCENE_DEBUG_PANEL, parcelLimits, playerConfi
 import { chatObservable } from '../shared/comms/chat'
 import { queueTrackingEvent } from '../shared/analytics'
 import { getUserProfile } from '../shared/comms/peers'
+import { sceneLifeCycleObservable } from '../decentraland-loader/lifecycle/controllers/scene'
 
 let gameInstance!: GameInstance
 
@@ -83,8 +84,8 @@ const browserInterface = {
     switch (eventType) {
       case 'SceneReady': {
         const { sceneId } = payload
-        defaultLogger.info(`SceneReady ${sceneId}`)
-        // TODO - check and wait for the other scene ready message and finally send loading screen message - moliva - 08/08/2019
+
+        sceneLifeCycleObservable.notifyObservers({ sceneId, status: 'ready' })
         break
       }
       case 'ActivateRenderingACK': {

--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -227,6 +227,7 @@ class UnityParcelScene extends UnityScene<LoadableParcelScene> {
 export async function initializeEngine(_gameInstance: GameInstance) {
   gameInstance = _gameInstance
 
+  setLoadingScreenVisible(true)
   unityInterface.DeactivateRendering()
 
   unityInterface.SetPosition(lastPlayerPosition.x, lastPlayerPosition.y, lastPlayerPosition.z)

--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -80,16 +80,14 @@ const browserInterface = {
   },
 
   ControlEvent({ eventType, payload }: { eventType: string; payload: any }) {
-    // TODO - delegate to lifecycle manager - moliva - 08/08/2019
     switch (eventType) {
       case 'SceneReady': {
         const { sceneId } = payload
-
         sceneLifeCycleObservable.notifyObservers({ sceneId, status: 'ready' })
         break
       }
       case 'ActivateRenderingACK': {
-        // TODO - remove loading screen effectively - moliva - 08/08/2019
+        setLoadingScreenVisible(false)
         break
       }
       default: {
@@ -98,6 +96,10 @@ const browserInterface = {
       }
     }
   }
+}
+
+function setLoadingScreenVisible(shouldShow: boolean) {
+  document.getElementById('overlay')!.style.display = shouldShow ? 'block' : 'none'
 }
 
 const unityInterface = {
@@ -146,6 +148,10 @@ const unityInterface = {
 
   SetEngineDebugPanel() {
     gameInstance.SendMessage('SceneController', 'SetEngineDebugPanel')
+  },
+
+  ActivateRendering() {
+    gameInstance.SendMessage('SceneController', 'ActivateRendering')
   },
 
   UnlockCursor() {
@@ -275,6 +281,12 @@ export async function startUnityParcelLoading() {
       lands.forEach($ => {
         unityInterface.UnloadScene($.sceneId)
       })
+    },
+    onPositionSettled: () => {
+      unityInterface.ActivateRendering()
+    },
+    onPositionUnsettled: () => {
+      setLoadingScreenVisible(true)
     }
   })
 }

--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -13,7 +13,8 @@ import {
   ILandToLoadableParcelScene,
   IScene,
   MappingsResponse,
-  ILand
+  ILand,
+  Profile
 } from '../shared/types'
 import { DevTools } from '../shared/apis/DevTools'
 import { gridToWorld } from '../atomicHelpers/parcelScenePositions'
@@ -39,7 +40,6 @@ import { Vector3, Quaternion, ReadOnlyVector3, ReadOnlyQuaternion } from '../dec
 import { DEBUG, ENGINE_DEBUG_PANEL, SCENE_DEBUG_PANEL, parcelLimits, playerConfigurations } from '../config'
 import { chatObservable } from '../shared/comms/chat'
 import { queueTrackingEvent } from '../shared/analytics'
-import { Profile } from '../shared/types'
 import { getUserProfile } from '../shared/comms/peers'
 
 let gameInstance!: GameInstance
@@ -76,6 +76,26 @@ const browserInterface = {
 
   PreloadFinished(data: { sceneId: string }) {
     // stub. there is no code about this in unity side yet
+  },
+
+  ControlEvent({ eventType, payload }: { eventType: string; payload: any }) {
+    // TODO - delegate to lifecycle manager - moliva - 08/08/2019
+    switch (eventType) {
+      case 'SceneReady': {
+        const { sceneId } = payload
+        defaultLogger.info(`SceneReady ${sceneId}`)
+        // TODO - check and wait for the other scene ready message and finally send loading screen message - moliva - 08/08/2019
+        break
+      }
+      case 'ActivateRenderingACK': {
+        // TODO - remove loading screen effectively - moliva - 08/08/2019
+        break
+      }
+      default: {
+        defaultLogger.warn(`Unknown event type ${eventType}, ignoring`)
+        break
+      }
+    }
   }
 }
 

--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -227,6 +227,8 @@ class UnityParcelScene extends UnityScene<LoadableParcelScene> {
 export async function initializeEngine(_gameInstance: GameInstance) {
   gameInstance = _gameInstance
 
+  unityInterface.DeactivateRendering()
+
   unityInterface.SetPosition(lastPlayerPosition.x, lastPlayerPosition.y, lastPlayerPosition.z)
 
   if (DEBUG) {
@@ -310,7 +312,6 @@ async function initializeDecentralandUI() {
 
   await ensureUiApis(worker)
 
-  unityInterface.DeactivateRendering()
   unityInterface.CreateUIScene({ id: getParcelSceneID(scene), baseUrl: scene.data.baseUrl })
   unityInterface.LoadProfile(getUserProfile().profile)
 }

--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -310,6 +310,7 @@ async function initializeDecentralandUI() {
 
   await ensureUiApis(worker)
 
+  unityInterface.DeactivateRendering()
   unityInterface.CreateUIScene({ id: getParcelSceneID(scene), baseUrl: scene.data.baseUrl })
   unityInterface.LoadProfile(getUserProfile().profile)
 }

--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -150,11 +150,12 @@ const unityInterface = {
   SetEngineDebugPanel() {
     gameInstance.SendMessage('SceneController', 'SetEngineDebugPanel')
   },
-
   ActivateRendering() {
     gameInstance.SendMessage('SceneController', 'ActivateRendering')
   },
-
+  DeactivateRendering() {
+    gameInstance.SendMessage('SceneController', 'DeactivateRendering')
+  },
   UnlockCursor() {
     gameInstance.SendMessage('MouseCatcher', 'UnlockCursor')
   }
@@ -288,6 +289,7 @@ export async function startUnityParcelLoading() {
     },
     onPositionUnsettled: () => {
       setLoadingScreenVisible(true)
+      unityInterface.DeactivateRendering()
     }
   })
 }

--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -101,6 +101,7 @@ const browserInterface = {
 
 function setLoadingScreenVisible(shouldShow: boolean) {
   document.getElementById('overlay')!.style.display = shouldShow ? 'block' : 'none'
+  document.getElementById('progress-bar')!.style.display = shouldShow ? 'block' : 'none'
 }
 
 const unityInterface = {

--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -30,7 +30,8 @@ import {
   getSceneWorkerBySceneID,
   getParcelSceneID,
   stopParcelSceneWorker,
-  loadParcelScene
+  loadParcelScene,
+  worldRunningObservable
 } from '../shared/world/parcelSceneManager'
 import { SceneWorker, ParcelSceneAPI, hudWorkerUrl } from '../shared/world/SceneWorker'
 import { ensureUiApis } from '../shared/world/uiSceneInitializer'
@@ -87,7 +88,7 @@ const browserInterface = {
         break
       }
       case 'ActivateRenderingACK': {
-        setLoadingScreenVisible(false)
+        worldRunningObservable.notifyObservers(true)
         break
       }
       default: {
@@ -359,6 +360,12 @@ export async function loadPreviewScene() {
 
 teleportObservable.add((position: { x: number; y: number }) => {
   unityInterface.SetPosition(position.x * parcelLimits.parcelSize, 0, position.y * parcelLimits.parcelSize)
+})
+
+worldRunningObservable.add(isRunning => {
+  if (isRunning) {
+    setLoadingScreenVisible(false)
+  }
 })
 
 window['messages'] = (e: any) => chatObservable.notifyObservers(e)

--- a/static/index.html
+++ b/static/index.html
@@ -87,22 +87,23 @@
         height: 100%;
         display: inline-flex;
         background-color: #eb455a;
-        /* animation: progress_30 10s forwards; */
+        animation: progress_30 10s forwards;
       }
 
       .progress.loaded {
         z-index: 1;
       }
 
-      /* .progress.loaded .full {
+      .progress.loaded .full {
         animation: progress_50 5s forwards;
-      } */
-
-      .progress.loaded.ingame .full {
-        animation: progress_100 10s forwards;
       }
 
-      /* @keyframes progress_30 {
+      .progress.ingame .full {
+        animation: progress_100 10s forwards;
+        animation-iteration-count: infinite;
+      }
+
+      @keyframes progress_30 {
         from {
           width: 0;
         }
@@ -110,9 +111,9 @@
         to {
           width: 30%;
         }
-      } */
+      }
 
-      /* @keyframes progress_50 {
+      @keyframes progress_50 {
         from {
           width: 30%;
         }
@@ -120,7 +121,7 @@
         to {
           width: 50%;
         }
-      } */
+      }
 
       @keyframes progress_100 {
         from {
@@ -136,7 +137,7 @@
 
   <body class="dcl-loading">
     <div id="overlay"></div>
-    <div class="progress ingame">
+    <div id="progress-bar" class="progress ingame">
       <div class="full"></div>
     </div>
     <div id="gameContainer"></div>

--- a/static/index.html
+++ b/static/index.html
@@ -1,137 +1,161 @@
 <!DOCTYPE html>
 <html>
-
-<head>
-  <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-  <link rel='shortcut icon' type='image/x-icon' href='/favicon.ico' />
-  <title>Decentraland</title>
-  <style>
-    html,
-    body {
-      margin: 0;
-      padding: 0;
-      height: 100%;
-      overflow: hidden;
-      touch-action: none;
-    }
-
-    #gameContainer {
-      width: 100vw;
-      height: 100vh;
-      position: relative;
-    }
-
-    #gameContainer.loaded {
-      width: 100%;
-      height: 100%;
-      margin: auto;
-    }
-
-    #gameContainer.loaded,
-    body {
-      background: #292631 url(images/progress-logo.png) no-repeat center !important;
-      background-size: 309px 58px !important;
-    }
-
-    * {
-      box-sizing: border-box;
-    }
-
-    body {
-      color: #fff;
-      font-family: 'open sans', roboto, 'helvetica neue', sans-serif;
-      font-size: 0.8em;
-    }
-
-    canvas {
-      position: relative;
-      z-index: 1000;
-      width: 100%;
-      height: 100%;
-    }
-
-    .dcl-loading .progress {
-      display: block;
-    }
-
-    .progress {
-      position: absolute;
-      height: 30px;
-      width: 100%;
-      bottom: 0;
-      left: 0;
-      right: 0;
-      border-style: solid;
-      border-width: thick;
-      border-left: none;
-      border-right: none;
-      text-align: center;
-      border-color: #3a383b;
-      background: #3a383b;
-      display: none;
-    }
-
-    .progress .full {
-      float: left;
-      width: 0%;
-      height: 100%;
-      display: inline-flex;
-      background-color: #eb455a;
-      animation: progress_30 10s forwards;
-    }
-
-    .progress.loaded {
-      z-index: 1;
-    }
-
-    .progress.loaded .full {
-      animation: progress_50 5s forwards;
-    }
-
-    @keyframes progress_30 {
-      from {
-        width: 0;
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
+    <title>Decentraland</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        touch-action: none;
       }
 
-      to {
-        width: 30%;
-      }
-    }
-
-    @keyframes progress_50 {
-      from {
-        width: 30%;
+      #gameContainer {
+        width: 100vw;
+        height: 100vh;
+        position: relative;
       }
 
-      to {
-        width: 50%;
+      #gameContainer.loaded {
+        width: 100%;
+        height: 100%;
+        margin: auto;
       }
-    }
-  </style>
-</head>
 
-<body class="dcl-loading">
-  <div class="progress">
-    <div class="full"></div>
-  </div>
-  <div id="gameContainer"></div>
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-63691338-5"></script>
-  <script>
-    window.dataLayer = window.dataLayer || []
+      #gameContainer.loaded,
+      body {
+        background: #292631 url(images/progress-logo.png) no-repeat center !important;
+        background-size: 309px 58px !important;
+      }
 
-    function gtag() {
-      dataLayer.push(arguments)
-    }
-    gtag('js', new Date())
-    gtag('config', 'UA-63691338-5')
-  </script>
+      * {
+        box-sizing: border-box;
+      }
 
-  <script>
-    // prettier-ignore
-    !function () { var analytics = window.analytics = window.analytics || []; if (!analytics.initialize) if (analytics.invoked) window.console && console.error && console.error("Segment snippet included twice."); else { analytics.invoked = !0; analytics.methods = ["trackSubmit", "trackClick", "trackLink", "trackForm", "pageview", "identify", "reset", "group", "track", "ready", "alias", "debug", "page", "once", "off", "on"]; analytics.factory = function (t) { return function () { var e = Array.prototype.slice.call(arguments); e.unshift(t); analytics.push(e); return analytics } }; for (var t = 0; t < analytics.methods.length; t++) { var e = analytics.methods[t]; analytics[e] = analytics.factory(e) } analytics.load = function (t, e) { var n = document.createElement("script"); n.type = "text/javascript"; n.async = !0; n.src = "https://cdn.segment.com/analytics.js/v1/" + t + "/analytics.min.js"; var a = document.getElementsByTagName("script")[0]; a.parentNode.insertBefore(n, a); analytics._loadOptions = e }; analytics.SNIPPET_VERSION = "4.1.0"; } }();
-  </script>
-</body>
-<script src="unity/Build/DCLUnityLoader.js"></script>
-<script defer async src="dist/unity.js"></script>
+      body {
+        color: #fff;
+        font-family: 'open sans', roboto, 'helvetica neue', sans-serif;
+        font-size: 0.8em;
+      }
 
+      canvas {
+        position: relative;
+        z-index: 1000;
+        width: 100%;
+        height: 100%;
+      }
+
+      .dcl-loading .progress {
+        display: block;
+      }
+
+      #overlay {
+        display: block;
+        width: 100%;
+        height: 100%;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: 2;
+      }
+
+      .progress {
+        position: absolute;
+        height: 30px;
+        width: 100%;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        border-style: solid;
+        border-width: thick;
+        border-left: none;
+        border-right: none;
+        text-align: center;
+        border-color: #3a383b;
+        background: #3a383b;
+        display: none;
+      }
+
+      .progress .full {
+        float: left;
+        width: 0%;
+        height: 100%;
+        display: inline-flex;
+        background-color: #eb455a;
+        /* animation: progress_30 10s forwards; */
+      }
+
+      .progress.loaded {
+        z-index: 1;
+      }
+
+      /* .progress.loaded .full {
+        animation: progress_50 5s forwards;
+      } */
+
+      .progress.loaded.ingame .full {
+        animation: progress_100 10s forwards;
+      }
+
+      /* @keyframes progress_30 {
+        from {
+          width: 0;
+        }
+
+        to {
+          width: 30%;
+        }
+      } */
+
+      /* @keyframes progress_50 {
+        from {
+          width: 30%;
+        }
+
+        to {
+          width: 50%;
+        }
+      } */
+
+      @keyframes progress_100 {
+        from {
+          width: 0%;
+        }
+
+        to {
+          width: 100%;
+        }
+      }
+    </style>
+  </head>
+
+  <body class="dcl-loading">
+    <div id="overlay"></div>
+    <div class="progress ingame">
+      <div class="full"></div>
+    </div>
+    <div id="gameContainer"></div>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-63691338-5"></script>
+    <script>
+      window.dataLayer = window.dataLayer || []
+
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag('js', new Date())
+      gtag('config', 'UA-63691338-5')
+    </script>
+
+    <script>
+      // prettier-ignore
+      !function () { var analytics = window.analytics = window.analytics || []; if (!analytics.initialize) if (analytics.invoked) window.console && console.error && console.error("Segment snippet included twice."); else { analytics.invoked = !0; analytics.methods = ["trackSubmit", "trackClick", "trackLink", "trackForm", "pageview", "identify", "reset", "group", "track", "ready", "alias", "debug", "page", "once", "off", "on"]; analytics.factory = function (t) { return function () { var e = Array.prototype.slice.call(arguments); e.unshift(t); analytics.push(e); return analytics } }; for (var t = 0; t < analytics.methods.length; t++) { var e = analytics.methods[t]; analytics[e] = analytics.factory(e) } analytics.load = function (t, e) { var n = document.createElement("script"); n.type = "text/javascript"; n.async = !0; n.src = "https://cdn.segment.com/analytics.js/v1/" + t + "/analytics.min.js"; var a = document.getElementsByTagName("script")[0]; a.parentNode.insertBefore(n, a); analytics._loadOptions = e }; analytics.SNIPPET_VERSION = "4.1.0"; } }();
+    </script>
+  </body>
+  <script src="unity/Build/DCLUnityLoader.js"></script>
+  <script defer async src="dist/unity.js"></script>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -99,8 +99,7 @@
       }
 
       .progress.ingame .full {
-        animation: progress_100 10s forwards;
-        animation-iteration-count: infinite;
+        animation: progress_100 50s forwards;
       }
 
       @keyframes progress_30 {

--- a/static/index.html
+++ b/static/index.html
@@ -54,7 +54,7 @@
       }
 
       #overlay {
-        display: block;
+        display: none;
         width: 100%;
         height: 100%;
         top: 0;

--- a/static/unity/Build/unity.data.unityweb
+++ b/static/unity/Build/unity.data.unityweb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a7f83fd85d2092b05ead5e0a69251c7bbf1e9e424c988dac86cd119fd379e2b9
-size 5615612
+oid sha256:f0151f4955d7f4d6adbe3bde0fcc05833637ff5e247481b2f6e1b52cfc482742
+size 5584039

--- a/static/unity/Build/unity.data.unityweb
+++ b/static/unity/Build/unity.data.unityweb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c400840c283d57da844fc44df28cb8a95a4ae91142af69c02c32d9da6607310d
-size 5196039
+oid sha256:a7f83fd85d2092b05ead5e0a69251c7bbf1e9e424c988dac86cd119fd379e2b9
+size 5615612

--- a/static/unity/Build/unity.wasm.code.unityweb
+++ b/static/unity/Build/unity.wasm.code.unityweb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:77e4216104e1590f110b097ba35de5a1d80e467dd307248f43bad81edfc4d103
-size 4811171
+oid sha256:4d2bf00aa4ec660809c74d9731dde58a77ad29d385b49b18baba94dfae9a74ab
+size 4794707

--- a/static/unity/Build/unity.wasm.code.unityweb
+++ b/static/unity/Build/unity.wasm.code.unityweb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4d2bf00aa4ec660809c74d9731dde58a77ad29d385b49b18baba94dfae9a74ab
-size 4794707
+oid sha256:baa6c4036b2817c47a7bac9c85403eb0521bfab4f75f548f277b2a2b9085209a
+size 4819907

--- a/static/unity/Build/unity.wasm.framework.unityweb
+++ b/static/unity/Build/unity.wasm.framework.unityweb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:074d9fc290e6780c59b8caafd2c547b50b9542595f7c7207735d12184baad1c1
-size 75447
+oid sha256:3ba042cb9956e7370af85f0b09f8d7cfa650704c638e7a588f44486d84487bc2
+size 75456

--- a/static/unity/Build/unity.wasm.framework.unityweb
+++ b/static/unity/Build/unity.wasm.framework.unityweb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3ba042cb9956e7370af85f0b09f8d7cfa650704c638e7a588f44486d84487bc2
-size 75456
+oid sha256:fe78ed3ad37054aed3f5e4f851764ad5a109ab29781ec200d29ebc51a77bce12
+size 75462

--- a/test/index.ts
+++ b/test/index.ts
@@ -34,7 +34,6 @@ import './unityIntegration/ecs/math/vector3.test'
 import './interactions/click.test'
 
 /* PARCEL SCENES */
-import './parcelScenes/unmount.test'
 import './parcelScenes/gltfLimits.test'
 import './parcelScenes/triangleLimits.test'
 
@@ -45,7 +44,6 @@ import './visualValidation/atlas.test'
 import './visualValidation/aframePrimitives.test'
 import './visualValidation/avatar.test'
 import './visualValidation/skyAndLights.test'
-import './visualValidation/crocs.test'
 import './visualValidation/parcel-shape.test'
 import './visualValidation/changeMaterial.test'
 import './visualValidation/text.test'

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -29,6 +29,8 @@ import { BasicShape } from 'engine/components/disposableComponents/DisposableCom
 import { initHudSystem } from 'engine/dcl/widgets/ui'
 import { AVATAR_OBSERVABLE } from 'decentraland-ecs/src/decentraland/Types'
 import { deleteUnusedTextures } from 'engine/renderer/monkeyLoader'
+import { worldRunningObservable } from '../packages/shared/world/worldState'
+import { sceneLifeCycleObservable } from '../packages/decentraland-loader/lifecycle/controllers/scene'
 
 const port = process.env.PORT || 8080
 
@@ -482,6 +484,10 @@ export function testScene(
       while (!sceneHost.didStart) {
         await sleep(10)
       }
+
+      // emulate system events
+      sceneLifeCycleObservable.notifyObservers({ sceneId: parcelScene.data.sceneId, status: 'ready' })
+      worldRunningObservable.notifyObservers(true)
 
       await parcelScene.context
     })


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->
Closes #244 , #351  .

# What? <!-- what is this PR? -->
Introduce a way to manage state changes in Explorer life cycle and communication with the engine, while making changes to how we deal with scene load requests and loading screen management.

# Why? <!-- Explain the reason -->
This will enable us to make changes in the lifecycle in a more simple and controlled way and coordinate this state changes with the engine.
