### PR TITLE
Ensure we send ICE candidates only after sending answer

### DIFF
--- a/packages/shared/comms/BrokerConnection.ts
+++ b/packages/shared/comms/BrokerConnection.ts
@@ -205,6 +205,8 @@ export class BrokerConnection implements IBrokerConnection {
               msg.setData(data)
               this.sendCoordinatorMessage(msg)
             }
+
+            this.webRtcConn!.onicecandidate = this.onIceCandidate
           } catch (err) {
             this.logger.error(err)
           }
@@ -254,7 +256,6 @@ export class BrokerConnection implements IBrokerConnection {
       this.logger.log(`ice connection state: ${this.webRtcConn!.iceConnectionState}`)
     }
 
-    this.webRtcConn.onicecandidate = this.onIceCandidate
     this.webRtcConn.ondatachannel = this.onDataChannel
   }
 
@@ -280,7 +281,7 @@ export class BrokerConnection implements IBrokerConnection {
   }
 
   private onIceCandidate = (event: RTCPeerConnectionIceEvent) => {
-    if (event.candidate !== null) {
+    if (event.candidate && event.candidate.candidate) {
       const msg = new WebRtcMessage()
       msg.setType(MessageType.WEBRTC_ICE_CANDIDATE)
       // TODO: Ensure commServerAlias, it may be null

--- a/test/unit/communications.test.tsx
+++ b/test/unit/communications.test.tsx
@@ -245,10 +245,10 @@ describe('Communications', function() {
     describe('webrtc', () => {
       it('onicecandidate', () => {
         connection.commServerAlias = 1
-
         const sdp = 'candidate:702786350 2 udp 41819902 8.8.8.8 60769 typ relay raddr 8.8.8.8'
         const candidate = new RTCIceCandidate({ candidate: sdp, sdpMid: '0', sdpMLineIndex: 0 })
         const event = new RTCPeerConnectionIceEvent('icecandidate', { candidate })
+        connection.webRtcConn!.onicecandidate = connection['onIceCandidate']
         connection.webRtcConn!.onicecandidate!(event)
         expect(webSocket.send).to.have.been.calledWithMatch((bytes: Uint8Array) => {
           const msg = WebRtcMessage.deserializeBinary(bytes)


### PR DESCRIPTION
This is a requirement of ICE protocol, even with trickle enabled