### PR TITLE
feat: create export.html + add static_world state

### DIFF
--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -82,10 +82,12 @@ export namespace visualConfigurations {
 export const PREVIEW: boolean = !!(global as any).preview
 export const EDITOR: boolean = !!(global as any).isEditor
 
+export const STATIC_WORLD = location.search.indexOf('STATIC_WORLD') !== -1 || !!(global as any).staticWorld
+
 // Development
 export const ENABLE_WEB3 = location.search.indexOf('ENABLE_WEB3') !== -1 || !!(global as any).enableWeb3 || EDITOR
-export const DEBUG = location.search.indexOf('DEBUG_MODE') !== -1 || !!(global as any).mocha || PREVIEW || EDITOR
 export const USE_LOCAL_COMMS = location.search.indexOf('LOCAL_COMMS') !== -1 || PREVIEW
+export const DEBUG = location.search.indexOf('DEBUG_MODE') !== -1 || !!(global as any).mocha || PREVIEW || EDITOR
 export const DEBUG_ANALYTICS = location.search.indexOf('DEBUG_ANALYTICS') !== -1
 export const DEBUG_MOBILE = location.search.indexOf('DEBUG_MOBILE') !== -1
 export const DEBUG_MESSAGES = location.search.indexOf('DEBUG_MESSAGES') !== -1

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -3,7 +3,7 @@ import { Auth } from './auth'
 import './apis/index'
 import './events'
 
-import { ETHEREUM_NETWORK, setNetwork, getTLD, PREVIEW, DEBUG, ENABLE_WEB3 } from '../config'
+import { ETHEREUM_NETWORK, setNetwork, getTLD, PREVIEW, DEBUG, ENABLE_WEB3, STATIC_WORLD } from '../config'
 
 import { initializeUrlPositionObserver } from './world/positionThings'
 import { connect } from './comms'
@@ -74,14 +74,6 @@ export async function initShared(container: HTMLElement): Promise<ETHEREUM_NETWO
   await setNetwork(net)
   console['groupEnd']()
 
-  console['group']('connect#comms')
-  await connect(
-    userId,
-    net,
-    auth
-  )
-  console['groupEnd']()
-
   initializeUrlPositionObserver()
 
   // Warn in case wallet is set in mainnet
@@ -94,6 +86,19 @@ export async function initShared(container: HTMLElement): Promise<ETHEREUM_NETWO
     )
     document.head.appendChild(style)
   }
+
+  // DCL Servers connections/requests after this
+  if (STATIC_WORLD) {
+    return net
+  }
+
+  console['group']('connect#comms')
+  await connect(
+    userId,
+    net,
+    auth
+  )
+  console['groupEnd']()
 
   // initialize profile
   console['group']('connect#profile')

--- a/static/export.html
+++ b/static/export.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
+    <title>{{ scene.display.title }}</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        touch-action: none;
+      }
+
+      #gameContainer {
+        width: 100vw;
+        height: 100vh;
+        position: relative;
+      }
+
+      #gameContainer.loaded {
+        width: 100%;
+        height: 100%;
+        margin: auto;
+      }
+
+      #gameContainer.loaded,
+      body {
+        background: #292631 url(images/progress-logo.png) no-repeat center !important;
+        background-size: 309px 58px !important;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        color: #fff;
+        font-family: 'open sans', roboto, 'helvetica neue', sans-serif;
+        font-size: 0.8em;
+      }
+
+      canvas {
+        position: relative;
+        z-index: 1000;
+        width: 100%;
+        height: 100%;
+      }
+
+      .dcl-loading .progress {
+        display: block;
+      }
+
+      .progress {
+        position: absolute;
+        height: 30px;
+        width: 100%;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        border-style: solid;
+        border-width: thick;
+        border-left: none;
+        border-right: none;
+        text-align: center;
+        border-color: #3a383b;
+        background: #3a383b;
+        display: none;
+      }
+
+      .progress .full {
+        float: left;
+        width: 0%;
+        height: 100%;
+        display: inline-flex;
+        background-color: #eb455a;
+        animation: progress_30 10s forwards;
+      }
+
+      .progress.loaded {
+        z-index: 1;
+      }
+
+      .progress.loaded .full {
+        animation: progress_50 5s forwards;
+      }
+
+      @keyframes progress_30 {
+        from {
+          width: 0;
+        }
+
+        to {
+          width: 30%;
+        }
+      }
+
+      @keyframes progress_50 {
+        from {
+          width: 30%;
+        }
+
+        to {
+          width: 50%;
+        }
+      }
+    </style>
+  </head>
+
+  <body class="dcl-loading">
+    <div class="progress">
+      <div class="full"></div>
+    </div>
+    <div id="gameContainer"></div>
+    <script>
+      window['staticWorld'] = true
+    </script>
+  </body>
+  <script src="/unity/Build/DCLUnityLoader.js"></script>
+  <script defer async src="/preview.js"></script>
+</html>


### PR DESCRIPTION
# What? <!-- what is this PR? -->
It creates the `STATIC_WORLD` explorer state which avoids the need of any kind of server to work (such as comms, profile, etc.)

# Why? <!-- Explain the reason -->
So features like `dcl export` or static scenes can exist.
