### PR TITLE
feat: implement new spawning points

### DIFF
--- a/packages/entryPoints/index.ts
+++ b/packages/entryPoints/index.ts
@@ -44,7 +44,7 @@ bodyReadyFuture
   .catch(handleError)
 
 function setInitialPosition(initialLand: ILand) {
-  const newPosition = getWorldSpawnpoint(initialLand)
+  const newPosition = getWorldSpawnpoint(initialLand).position
   const result = new BABYLON.Vector3(newPosition.x, newPosition.y, newPosition.z)
   if (scene.activeCamera) {
     scene.activeCamera.position.copyFrom(result)

--- a/packages/entryPoints/index.ts
+++ b/packages/entryPoints/index.ts
@@ -8,6 +8,7 @@ import { WebGLParcelScene } from '../engine/dcl/WebGLParcelScene'
 import { enableMiniMap } from '../engine/dcl/widgets/minimap'
 import { getWorldSpawnpoint } from '../shared/world/positionThings'
 import { worldRunningObservable } from '../shared/world/worldState'
+import { ILand } from '../shared/types'
 
 document.body.classList.remove('dcl-loading')
 
@@ -20,15 +21,9 @@ async function loadClient() {
 
   await enableParcelSceneLoading({
     parcelSceneClass: WebGLParcelScene,
-    onPositionSettled: () => {
+    onPositionSettled: initialLand => {
+      initialLand && setInitialPosition(initialLand)
       worldRunningObservable.notifyObservers(true)
-    },
-    onSpawnpoint: initialLand => {
-      const newPosition = getWorldSpawnpoint(initialLand)
-      const result = new BABYLON.Vector3(newPosition.x, newPosition.y, newPosition.z)
-      if (scene.activeCamera) {
-        scene.activeCamera.position.copyFrom(result)
-      }
     },
     preloadScene: async () => true
   })
@@ -47,6 +42,14 @@ bodyReadyFuture
       .catch(handleError)
   })
   .catch(handleError)
+
+function setInitialPosition(initialLand: ILand) {
+  const newPosition = getWorldSpawnpoint(initialLand)
+  const result = new BABYLON.Vector3(newPosition.x, newPosition.y, newPosition.z)
+  if (scene.activeCamera) {
+    scene.activeCamera.position.copyFrom(result)
+  }
+}
 
 function handleError(e: Error) {
   container.classList.remove('dcl-loading')

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -1,5 +1,6 @@
 import { parseParcelPosition } from 'atomicHelpers/parcelScenePositions'
 import { Wearable } from '../decentraland-ecs/src/decentraland/AvatarShape'
+import { Vector3Component } from '../atomicHelpers/landHelpers'
 
 export type MappingsResponse = {
   parcel_id: string
@@ -160,6 +161,7 @@ export interface IScene {
     base: string
     parcels: string[]
   }
+  spawnPoints?: SpawnPoint[]
   _mappings?: Record<string, string>
 }
 
@@ -180,6 +182,17 @@ export interface ILand {
   scene: IScene
   baseUrl: string
   mappingsResponse: MappingsResponse
+}
+
+export type SpawnPoint = {
+  name?: string
+  position: {
+    x: number | number[]
+    y: number | number[]
+    z: number | number[]
+  }
+  default?: boolean
+  cameraTarget?: Vector3Component
 }
 
 export type SoundComponent = {

--- a/packages/shared/world/parcelSceneManager.ts
+++ b/packages/shared/world/parcelSceneManager.ts
@@ -12,10 +12,9 @@ import { worldRunningObservable } from './worldState'
 export type EnableParcelSceneLoadingOptions = {
   parcelSceneClass: { new (x: EnvironmentData<LoadableParcelScene>): ParcelSceneAPI }
   preloadScene: (parcelToLoad: ILand) => Promise<any>
-  onSpawnpoint?: (initialLand: ILand) => void
+  onPositionSettled?: (initialLand?: ILand) => void
   onLoadParcelScenes?(x: ILand[]): void
   onUnloadParcelScenes?(x: ILand[]): void
-  onPositionSettled?(): void
   onPositionUnsettled?(): void
 }
 
@@ -104,10 +103,9 @@ export async function enableParcelSceneLoading(options: EnableParcelSceneLoading
     }
   })
 
-  ret.on('Position.settled', async (opt: { sceneId: string }) => {
-    // TODO - readd spawnpoint - moliva - 15/08/2019
+  ret.on('Position.settled', async (opts: { sceneId: string }) => {
     if (options.onPositionSettled) {
-      options.onPositionSettled()
+      options.onPositionSettled(opts.sceneId ? await ret.getParcelData(opts.sceneId) : undefined)
     }
   })
 

--- a/packages/shared/world/positionThings.ts
+++ b/packages/shared/world/positionThings.ts
@@ -78,6 +78,13 @@ export function initializeUrlPositionObserver() {
   }
 }
 
+/**
+ * Computes the spawn point based on a scene.
+ *
+ * The computation takes the spawning points defined in the scene document and computes the spawning point in the world based on the base parcel position.
+ *
+ * @param land Scene on which the player is spawning
+ */
 export function getWorldSpawnpoint(land: ILand): Vector3 {
   const spawnpoint = getSpawnpoint(land)
 
@@ -85,13 +92,15 @@ export function getWorldSpawnpoint(land: ILand): Vector3 {
     return lastPlayerPosition
   }
 
+  const baseParcel = land.scene.scene.base
+  const [bx, by] = baseParcel.split(',')
+
+  const basePosition = new Vector3()
+
+  gridToWorld(parseInt(bx, 10), parseInt(by, 10), basePosition)
   const [x, y, z] = spawnpoint.split(',')
 
-  return new Vector3(
-    (lastPlayerPosition.x += parseFloat(x)),
-    (lastPlayerPosition.y += parseFloat(y)),
-    (lastPlayerPosition.z += parseFloat(z))
-  )
+  return basePosition.add({ x, y, z })
 }
 
 function getSpawnpoint(land: ILand) {

--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -291,8 +291,8 @@ export async function startUnityParcelLoading() {
       })
     },
     onPositionSettled: land => {
-      land && setInitialPosition(land)
       unityInterface.ActivateRendering()
+      land && setInitialPosition(land)
     },
     onPositionUnsettled: () => {
       setLoadingScreenVisible(true)

--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -43,6 +43,7 @@ import { queueTrackingEvent } from '../shared/analytics'
 import { getUserProfile } from '../shared/comms/peers'
 import { sceneLifeCycleObservable } from '../decentraland-loader/lifecycle/controllers/scene'
 import { worldRunningObservable } from '../shared/world/worldState'
+import { Vector3Component } from '../atomicHelpers/landHelpers'
 
 let gameInstance!: GameInstance
 
@@ -122,10 +123,10 @@ const unityInterface = {
     gameInstance.SendMessage('SceneController', 'CreateUIScene', JSON.stringify(data))
   },
   /** Sends the camera position to the engine */
-  SetPosition(x: number, y: number, z: number) {
+  SetPosition(x: number, y: number, z: number, cameraTarget?: Vector3Component) {
     const theY = y <= 0 ? 2 : y
 
-    gameInstance.SendMessage('CharacterController', 'SetPosition', JSON.stringify({ x, y: theY, z }))
+    gameInstance.SendMessage('CharacterController', 'SetPosition', JSON.stringify({ x, y: theY, z, cameraTarget }))
   },
   /** Tells the engine which scenes to load */
   LoadParcelScenes(parcelsToLoad: LoadableParcelScene[]) {
@@ -261,9 +262,9 @@ export async function initializeEngine(_gameInstance: GameInstance) {
 }
 
 function setInitialPosition(initialLand: ILand) {
-  const newPosition = getWorldSpawnpoint(initialLand)
-  unityInterface.SetPosition(newPosition.x, newPosition.y, newPosition.z)
-  queueTrackingEvent('Scene Spawn', { parcel: initialLand.scene.scene.base, spawnpoint: newPosition })
+  const { position, cameraTarget } = getWorldSpawnpoint(initialLand)
+  unityInterface.SetPosition(position.x, position.y, position.z, cameraTarget)
+  queueTrackingEvent('Scene Spawn', { parcel: initialLand.scene.scene.base, spawnpoint: position })
 }
 
 export async function startUnityParcelLoading() {

--- a/public/test-parcels/-100.100.gamekit-cube/scene.json
+++ b/public/test-parcels/-100.100.gamekit-cube/scene.json
@@ -14,6 +14,17 @@
     "parcels": ["-100,100"],
     "base": "-100,100"
   },
+  "spawnPoints": [
+    {
+      "name": "spawn1",
+      "default": true,
+      "position": {
+        "x": 5,
+        "y": 0,
+        "z": 5
+      }
+    }
+  ],
   "policy": {
     "contentRating": "E",
     "fly": true,

--- a/public/test-parcels/0.0.genetic-experiment/scene.json
+++ b/public/test-parcels/0.0.genetic-experiment/scene.json
@@ -21,6 +21,34 @@
     "type": "webrtc",
     "signalling": "https://signalling-01.decentraland.org"
   },
+  "spawnPoints": [
+    {
+      "name": "inside",
+      "default": true,
+      "position": {
+        "x": [30.1, 40],
+        "y": 0,
+        "z": [30, 40.2]
+      }
+    },
+    {
+      "name": "corner",
+      "default": true,
+      "position": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    },
+    {
+      "name": "otherCorner",
+      "position": {
+        "x": 80,
+        "y": 0,
+        "z": 80
+      }
+    }
+  ],
   "policy": {
     "contentRating": "E",
     "fly": true,

--- a/public/test-parcels/0.0.genetic-experiment/scene.json
+++ b/public/test-parcels/0.0.genetic-experiment/scene.json
@@ -26,7 +26,7 @@
     "fly": true,
     "voiceEnabled": true,
     "blacklist": [],
-    "teleportPosition": ""
+    "teleportPosition": "30,0,30"
   },
   "main": "game.js",
   "tags": []


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->
Closes #310.

# What? <!-- what is this PR? -->
Reenables spawn points in Explorer following the new definition.

# Why? <!-- Explain the reason -->
Allow the scene developers to set default spawn points optionally randomized in an area, plus a set of other optional spawn points that will be used in the future.
