### PR TITLE
feat: add OpenWebURL to the explorer browser interface

### DIFF
--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -76,6 +76,10 @@ const browserInterface = {
     }
   },
 
+  OpenWebURL(data: { url: string }) {
+    window.open(data.url, '_blank')
+  },
+
   PreloadFinished(data: { sceneId: string }) {
     // stub. there is no code about this in unity side yet
   },


### PR DESCRIPTION
Allow the renderer to open a Web URL.