### PR TITLE
fix: avatars-storage

### DIFF
--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -179,7 +179,7 @@ export function getServerConfigurations() {
       server: `https://avatars-api.decentraland.${TLDDefault}/`,
       catalog: 'https://avatar-assets.now.sh',
       contents: `https://s3.amazonaws.com/content-service.decentraland.org/`,
-      presets: `https://s3.amazonaws.com/avatars-storage.decentraland.org/mobile-avatars`
+      presets: `https://avatars-storage.decentraland.org/mobile-avatars`
     },
     darApi:
       TLDDefault === 'zone' || TLDDefault === 'today'


### PR DESCRIPTION
Failing to retrieve directly from S3. We should use the actual URL.