### PR TITLE
fix: override entry points sources in tsconfig

### DIFF
--- a/packages/entryPoints/tsconfig.json
+++ b/packages/entryPoints/tsconfig.json
@@ -5,5 +5,8 @@
     "strict": true,
     "strictNullChecks": true
   },
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "include": [
+    "*.ts"
+  ]
 }


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Overrides entry points sources in tsconfig

# Why? <!-- Explain the reason -->
By default this tsconfig will use the sources of its parent (`../../src/**/*` and `../../test/**/*`) which are not the desired files to compile and may not even be available (e.g. in the context of the CI `publish-ecs-next` stage).

This should solve the issues in the pipeline stage for publishing to ECS.