### PR TITLE
fix: drop "entity is already in the engine"

### DIFF
--- a/packages/decentraland-ecs/src/ecs/Engine.ts
+++ b/packages/decentraland-ecs/src/ecs/Engine.ts
@@ -61,7 +61,6 @@ export class Engine implements IEngine {
     const parent = entity.getParent()
 
     if (entity.isAddedToEngine()) {
-      log('The entity is already in the engine. Please fix this')
       return entity
     }
 


### PR DESCRIPTION
Drop this message -- not very useful