### PR TITLE
fix: remove scene ready observer when it corresponds

### DIFF
--- a/packages/shared/world/parcelSceneManager.ts
+++ b/packages/shared/world/parcelSceneManager.ts
@@ -89,9 +89,9 @@ export async function enableParcelSceneLoading(options: EnableParcelSceneLoading
 
     const observer = sceneLifeCycleObservable.add(sceneStatus => {
       if (sceneStatus.sceneId === sceneId) {
+        sceneLifeCycleObservable.remove(observer)
         ret.notify('Scene.status', sceneStatus)
       }
-      sceneLifeCycleObservable.remove(observer)
     })
 
     // tell the engine to load the parcel scene


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->
Closes #437. 

# What? <!-- what is this PR? -->
Remove scene ready observer only when the event is for that particular scene, otherwise it will never be notified about the readiness of it.
