### PR TITLE
feat: add secure radius before scenes are unloaded

### DIFF
--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -40,6 +40,7 @@ export namespace parcelLimits {
   export const centimeter = 0.01
 
   export const visibleRadius = 4
+  export const secureRadius = 4
 
   export const maxX = 3000
   export const maxZ = 3000

--- a/packages/decentraland-loader/lifecycle/controllers/parcel.ts
+++ b/packages/decentraland-loader/lifecycle/controllers/parcel.ts
@@ -43,11 +43,15 @@ export class ParcelLifeCycleController extends EventEmitter {
       return this.parcelSighted(parcel)
     })
 
-    const newlyOOSParcels = [...this.currentlySightedParcels]
-      .filter(parcel => !sightedParcelsSet.has(parcel))
+    const secureParcels = new Set(parcelsInScope(this.config.lineOfSightRadius + this.config.secureRadius, position))
+
+    const currentlyPlusNewlySightedParcels = [...this.currentlySightedParcels] // this.currentlySightedParcels from t - 1 + newSightedParcels (added on this#parcelSighted)
+
+    const newlyOOSParcels = currentlyPlusNewlySightedParcels
+      .filter(parcel => !secureParcels.has(parcel))
       .filter(parcel => this.switchParcelToOutOfSight(parcel))
 
-    this.currentlySightedParcels = sightedParcelsSet
+    this.currentlySightedParcels = new Set(currentlyPlusNewlySightedParcels.filter($ => secureParcels.has($)))
 
     this.emit('Sighted', newlySightedParcels)
     this.emit('Lost sight', newlyOOSParcels)

--- a/packages/decentraland-loader/lifecycle/lib/scope.ts
+++ b/packages/decentraland-loader/lifecycle/lib/scope.ts
@@ -2,23 +2,29 @@ import { Vector2Component } from 'atomicHelpers/landHelpers'
 
 export interface ParcelConfigurationOptions {
   lineOfSightRadius: number
+  secureRadius: number
 }
 
 export function squareAndSum(a: number, b: number) {
   return a * a + b * b
 }
 
-const cachedDeltas: Vector2Component[] = []
+const cachedDeltas: { [limit: number]: Vector2Component[] } = {}
 
 export function parcelsInScope(lineOfSightRadius: number, position: Vector2Component): string[] {
   const result: string[] = []
-  let length = cachedDeltas.length
+  if (!cachedDeltas[lineOfSightRadius]) {
+    cachedDeltas[lineOfSightRadius] = []
+  }
+  let length = cachedDeltas[lineOfSightRadius].length
   if (!length) {
     calculateCachedDeltas(lineOfSightRadius)
-    length = cachedDeltas.length
+    length = cachedDeltas[lineOfSightRadius].length
   }
   for (let i = 0; i < length; i++) {
-    result.push(`${position.x + cachedDeltas[i].x},${position.y + cachedDeltas[i].y}`)
+    result.push(
+      `${position.x + cachedDeltas[lineOfSightRadius][i].x},${position.y + cachedDeltas[lineOfSightRadius][i].y}`
+    )
   }
   return result
 }
@@ -28,9 +34,9 @@ function calculateCachedDeltas(limit: number) {
   for (let x = -limit; x <= limit; x++) {
     for (let y = -limit; y <= limit; y++) {
       if (x * x + y * y <= squaredRadius) {
-        cachedDeltas.push({ x, y })
+        cachedDeltas[limit].push({ x, y })
       }
     }
   }
-  cachedDeltas.sort((a, b) => squareAndSum(a.x, a.y) - squareAndSum(b.x, b.y))
+  cachedDeltas[limit].sort((a, b) => squareAndSum(a.x, a.y) - squareAndSum(b.x, b.y))
 }

--- a/packages/decentraland-loader/lifecycle/manager.ts
+++ b/packages/decentraland-loader/lifecycle/manager.ts
@@ -57,6 +57,7 @@ export async function initParcelSceneWorker() {
   server.notify('Lifecycle.initialize', {
     contentServer: DEBUG ? resolveUrl(document.location.origin, '/local-ipfs') : getServerConfigurations().content,
     lineOfSightRadius: parcelLimits.visibleRadius,
+    secureRadius: parcelLimits.secureRadius,
     emptyScenes: ENABLE_EMPTY_SCENES && !(globalThis as any)['isRunningTests']
   })
 

--- a/packages/decentraland-loader/lifecycle/worker.ts
+++ b/packages/decentraland-loader/lifecycle/worker.ts
@@ -34,9 +34,12 @@ let downloadManager: SceneDataDownloadManager
 {
   connector.on(
     'Lifecycle.initialize',
-    (options: { contentServer: string; lineOfSightRadius: number; emptyScenes: boolean }) => {
+    (options: { contentServer: string; lineOfSightRadius: number; secureRadius: number; emptyScenes: boolean }) => {
       downloadManager = new SceneDataDownloadManager({ contentServer: options.contentServer })
-      parcelController = new ParcelLifeCycleController({ lineOfSightRadius: options.lineOfSightRadius })
+      parcelController = new ParcelLifeCycleController({
+        lineOfSightRadius: options.lineOfSightRadius,
+        secureRadius: options.secureRadius
+      })
       sceneController = new SceneLifeCycleController({ downloadManager, enabledEmpty: options.emptyScenes })
       positionController = new PositionLifecycleController(parcelController, sceneController)
 


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->
Fixes #341. 

# What? <!-- what is this PR? -->
Differentiate load and unload radius to improve experience while exploring the world.

# Why? <!-- Explain the reason -->
This helps the loading/unloading of scenes, making it less chaotic and easy to handle on the engine side as well.
