### PR TITLE
Fix ice candidates handler: always register it when creating the connection

### DIFF
--- a/test/unit/communications.test.tsx
+++ b/test/unit/communications.test.tsx
@@ -245,6 +245,7 @@ describe('Communications', function() {
     describe('webrtc', () => {
       it('onicecandidate', () => {
         connection.commServerAlias = 1
+        connection['remoteDescription'] = true
         const sdp = 'candidate:702786350 2 udp 41819902 8.8.8.8 60769 typ relay raddr 8.8.8.8'
         const candidate = new RTCIceCandidate({ candidate: sdp, sdpMid: '0', sdpMLineIndex: 0 })
         const event = new RTCPeerConnectionIceEvent('icecandidate', { candidate })

--- a/test/unit/communications.test.tsx
+++ b/test/unit/communications.test.tsx
@@ -111,6 +111,7 @@ describe('Communications', function() {
         setRemoteDescription: sinon.stub(),
         setLocalDescription: sinon.stub(),
         createAnswer: sinon.stub(),
+        remoteDescription: true,
         onicecandidate: connection.webRtcConn!.onicecandidate,
         ondatachannel: connection.webRtcConn!.ondatachannel
       }
@@ -245,7 +246,6 @@ describe('Communications', function() {
     describe('webrtc', () => {
       it('onicecandidate', () => {
         connection.commServerAlias = 1
-        connection['remoteDescription'] = true
         const sdp = 'candidate:702786350 2 udp 41819902 8.8.8.8 60769 typ relay raddr 8.8.8.8'
         const candidate = new RTCIceCandidate({ candidate: sdp, sdpMid: '0', sdpMLineIndex: 0 })
         const event = new RTCPeerConnectionIceEvent('icecandidate', { candidate })


### PR DESCRIPTION
Previously I have set the call of `onCandidate` after the `setRemoteDescription` call thinking the candidates will be buffered in the connection, but after testing it for a while in the server I realise that if the handler is not defined the candidates are simply lost. So, instead, if an ice candidate is gather but no remote description is set, we simply buffer them ourselves and process them all together after we set the remote description