### PR TITLE
chore: adding hold for stg deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,8 +45,8 @@ jobs:
       - run:
           name: Install differences in node_modules
           command: |
-              npm i
-              git checkout -- package-lock.json
+            npm i
+            git checkout -- package-lock.json
       - save_cache:
           name: Store node_modules cache
           paths:
@@ -55,13 +55,13 @@ jobs:
       - run:
           name: Run linters and checks
           command: |
-              make lint
-              npm outdated --depth 0 || true
+            make lint
+            npm outdated --depth 0 || true
       - run:
           name: Build decentraland-ecs
           command: |
-              make build-essentials
-              find public -name *.ts | xargs shasum packages/decentraland-ecs/dist/index.d.ts static/systems/scene.system.js | sort > .scene-system-checksum
+            make build-essentials
+            find public -name *.ts | xargs shasum packages/decentraland-ecs/dist/index.d.ts static/systems/scene.system.js | sort > .scene-system-checksum
       # TODO - reenable cache - moliva - 04/09/19
       # - restore_cache:
       #     name: Restore cached test scenes
@@ -70,7 +70,7 @@ jobs:
       - run:
           name: Build scenes
           command: |
-              make test-scenes
+            make test-scenes
       - save_cache:
           name: Store cached test scenes
           paths:
@@ -82,8 +82,8 @@ jobs:
       - run:
           name: Run tests
           command: |
-              make test-ci
-              npx codecov
+            make test-ci
+            npx codecov
       - store_artifacts:
           name: Save screenshots of visual tests
           path: test/diff
@@ -98,7 +98,7 @@ jobs:
       - run:
           name: Build deployment dist
           command: |
-              make build-deploy
+            make build-deploy
       - save_cache:
           name: Save the built files
           paths:
@@ -278,7 +278,16 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - hold-explorer:
+      - hold-explorer-prd:
+          type: approval
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+\.\d+\.\d(.*)/
+      - hold-explorer-stg:
           type: approval
           requires:
             - build
@@ -318,6 +327,7 @@ workflows:
           requires:
             - build
             - deploy-dev
+            - hold-explorer-stg
           filters:
             branches:
               ignore: /.*/
@@ -325,7 +335,7 @@ workflows:
               only: /^\d+\.\d+\.\d(.*)/
       - deploy-prd:
           requires:
-            - hold-explorer
+            - hold-explorer-prd
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Add hold for deployments to stg env, to avoid issues when trying to rollback to a previous deployment.
This is a temporal fix as part of a bigger refactor of the build/deployment pipeline.
