### PR TITLE
chore: refactor pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,10 +60,10 @@ jobs:
       - run:
           name: Build decentraland-ecs
           command: |
-              make build-essentials
-              mkdir -p scene-cache
-              cd scene-cache && find . -name '*.js' | xargs -I{} cp -f -t ../public/ --parents {}; cd ..
-              find public -name *.ts | xargs shasum packages/decentraland-ecs/dist/index.d.ts static/systems/scene.system.js | sort > .compiled-scene-checksum
+            make build-essentials
+            mkdir -p scene-cache
+            cd scene-cache && find . -name '*.js' | xargs -I{} cp -f -t ../public/ --parents {}; cd ..
+            find public -name *.ts | xargs shasum packages/decentraland-ecs/dist/index.d.ts static/systems/scene.system.js | sort > .compiled-scene-checksum
       - restore_cache:
           name: Restore cached test scenes, part I
           keys:
@@ -71,17 +71,17 @@ jobs:
       - run:
           name: Restore cached test scenes, part II
           command: |
-              touch static/systems/scene.system.js
-              cd scene-cache && find . -name '*.js' | xargs -I{} cp -f -t ../public/ --parents {}; cd ..
-              for compiled in `find public -name '*.js'`; do touch $compiled; done
+            touch static/systems/scene.system.js
+            cd scene-cache && find . -name '*.js' | xargs -I{} cp -f -t ../public/ --parents {}; cd ..
+            for compiled in `find public -name '*.js'`; do touch $compiled; done
       - run:
           name: Build scenes
           command: |
-              make test-scenes
+            make test-scenes
       - run:
           name: Build cache of test scenes
           command: |
-              cd public && find . -name '*.js' | xargs -I{} cp -f -t ../scene-cache/ --parents {}; cd ..
+            cd public && find . -name '*.js' | xargs -I{} cp -f -t ../scene-cache/ --parents {}; cd ..
       - save_cache:
           name: Store cached test scenes
           paths:
@@ -339,15 +339,17 @@ workflows:
             - hold-explorer-stg
           filters:
             branches:
-              ignore: /.*/
+              only: master
             tags:
               only: /^\d+\.\d+\.\d(.*)/
       - deploy-prd:
           requires:
+            - build
+            - deploy-stg
             - hold-explorer-prd
           filters:
             branches:
-              ignore: /.*/
+              only: master
             tags:
               only: /^\d+\.\d+\.\d(.*)/
       - publish-ecs-latest:

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ DIST_STATIC_FILES := static/export.html static/preview.html static/fonts static/
 DIST_PACKAGE_JSON := packages/decentraland-ecs/package.json
 
 build-deploy: $(DIST_ENTRYPOINTS) $(DIST_STATIC_FILES) $(SCENE_SYSTEM) $(INTERNAL_SCENES) ## Build all the entrypoints needed for a deployment
+	@node ./scripts/replaceVersion.js
 
 build-release: $(DIST_ENTRYPOINTS) $(DIST_STATIC_FILES) $(DIST_PACKAGE_JSON) ## Build all the entrypoints and run the `scripts/prepareDist` script
 	@node ./scripts/prepareDist.js

--- a/scripts/replaceVersion.ts
+++ b/scripts/replaceVersion.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// tslint:disable:no-console
+
+import fs = require('fs-extra')
+import path = require('path')
+import { readFileSync, writeFileSync } from 'fs-extra'
+import { execSync } from 'child_process'
+
+const root = path.resolve(__dirname, '..')
+const commitHash = execSync('git rev-parse HEAD')
+  .toString()
+  .trim()
+
+function replaceVersion(placeholder: string) {
+  const targetIndexHtml = path.resolve(root, 'static/index.html')
+
+  if (!fs.existsSync(targetIndexHtml)) {
+    throw new Error(`${targetIndexHtml} does not exist`)
+  }
+
+  const version = process.env.CIRCLE_TAG || process.env.TRAVIS_TAG || commitHash
+
+  console.log(`> replace '${placeholder}' -> '${version}' in html`)
+  {
+    let content = readFileSync(targetIndexHtml).toString()
+
+    if (!content.includes(`${placeholder}`)) {
+      throw new Error(`index.html is dirty and does\'t contain the text '${placeholder}'`)
+    }
+
+    content = content.replace(new RegExp(placeholder), version)
+
+    writeFileSync(targetIndexHtml, content)
+  }
+}
+
+// tslint:disable-next-line:semicolon
+;(async function() {
+  replaceVersion('EXPLORER_VERSION')
+})().catch(e => {
+  // tslint:disable-next-line:no-console
+  console.error(e)
+  process.exit(1)
+})

--- a/static/index.html
+++ b/static/index.html
@@ -172,6 +172,7 @@ if (document.domain.endsWith('.org')) {
 // End Rollbar Snippet
     </script>
   </body>
+  <script>console.log('Explorer version: EXPLORER_VERSION');</script>
   <script src="unity/Build/DCLUnityLoader.js"></script>
   <script defer async src="dist/unity.js"></script>
 </html>


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Enable deployments from master to staging and production environments.

# Why? <!-- Explain the reason -->
Towards a continuous delivery approach, this PR adds:
- Logging of the current version of the kernel
- Promoting build to deploy from dev to stg and prd environments in the same pipeline
This helps simplify the deployments of the explorer without the need to tag versions, which proves to be a redundant and even harmful task.
