### PR TITLE
feat: kernel can enable or disable unity HUDs

### DIFF
--- a/packages/entryPoints/preview.ts
+++ b/packages/entryPoints/preview.ts
@@ -6,7 +6,7 @@ global['preview'] = window['preview'] = true
 global['enableWeb3'] = window['enableWeb3']
 
 import { initializeUnity } from '../unity-interface/initializer'
-import { loadPreviewScene } from '../unity-interface/dcl'
+import { loadPreviewScene, HUD } from '../unity-interface/dcl'
 import { DEBUG_WS_MESSAGES } from '../config'
 import defaultLogger from 'shared/logger'
 import { future, IFuture } from 'fp-future'
@@ -83,6 +83,9 @@ function sceneRenderable() {
 
 initializeUnity(container)
   .then(async ret => {
+    HUD.Minimap.configure({ active: true })
+    HUD.Notification.configure({ active: true })
+
     const renderable = sceneRenderable()
 
     startPreviewWatcher()

--- a/packages/entryPoints/unity.ts
+++ b/packages/entryPoints/unity.ts
@@ -3,7 +3,7 @@ import { FAILED_FETCHING_UNITY } from 'shared/loading/types'
 import { worldToGrid } from '../atomicHelpers/parcelScenePositions'
 import defaultLogger from '../shared/logger'
 import { lastPlayerPosition, teleportObservable } from '../shared/world/positionThings'
-import { startUnityParcelLoading } from '../unity-interface/dcl'
+import { startUnityParcelLoading, HUD } from '../unity-interface/dcl'
 import { initializeUnity } from '../unity-interface/initializer'
 
 const container = document.getElementById('gameContainer')
@@ -12,14 +12,15 @@ if (!container) throw new Error('cannot find element #gameContainer')
 
 initializeUnity(container)
   .then(async _ => {
+    Object.keys(HUD).forEach($ => HUD[$].configure({ active: true }))
+
     await startUnityParcelLoading()
 
     _.instancedJS
       .then($ => teleportObservable.notifyObservers(worldToGrid(lastPlayerPosition)))
       .catch(defaultLogger.error)
-    document.body.classList.remove('dcl-loading');
-
-    (window as any).UnityLoader.Error.handler = (error: any) => {
+    document.body.classList.remove('dcl-loading')
+    ;(window as any).UnityLoader.Error.handler = (error: any) => {
       console.error(error)
       ReportFatalError(error.message)
     }

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -425,6 +425,10 @@ export type Notification = {
   externalCallbackID: string
 }
 
+export type HUDConfiguration = {
+  active: boolean
+}
+
 export function normalizeContentMappings(
   mappings: Record<string, string> | Array<ContentMapping>
 ): Array<ContentMapping> {

--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -110,8 +110,16 @@ export function setLoadingScreenVisible(shouldShow: boolean) {
   document.getElementById('progress-bar')!.style.display = shouldShow ? 'block' : 'none'
 }
 function ensureTeleportAnimation() {
-  document.getElementById('gameContainer')!.setAttribute('style', 'background: #151419 url(images/teleport.gif) no-repeat center !important; background-size: 194px 257px !important;')
-  document.body.setAttribute('style', 'background: #151419 url(images/teleport.gif) no-repeat center !important; background-size: 194px 257px !important;')
+  document
+    .getElementById('gameContainer')!
+    .setAttribute(
+      'style',
+      'background: #151419 url(images/teleport.gif) no-repeat center !important; background-size: 194px 257px !important;'
+    )
+  document.body.setAttribute(
+    'style',
+    'background: #151419 url(images/teleport.gif) no-repeat center !important; background-size: 194px 257px !important;'
+  )
 }
 
 const unityInterface = {
@@ -194,6 +202,18 @@ const unityInterface = {
   }
 }
 
+export const HUD: Record<string, { configure: (config: HUDConfiguration) => void }> = {
+  Minimap: {
+    configure: unityInterface.ConfigureMinimapHUD
+  },
+  Avatar: {
+    configure: unityInterface.ConfigureAvatarHUD
+  },
+  Notification: {
+    configure: unityInterface.ConfigureNotificationHUD
+  }
+}
+
 window['unityInterface'] = unityInterface
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -257,6 +277,12 @@ class UnityParcelScene extends UnityScene<LoadableParcelScene> {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+/**
+ *
+ * Common initialization logic for the unity engine
+ *
+ * @param _gameInstance Unity game instance
+ */
 export async function initializeEngine(_gameInstance: GameInstance) {
   gameInstance = _gameInstance
 
@@ -283,7 +309,7 @@ export async function initializeEngine(_gameInstance: GameInstance) {
     onMessage(type: string, message: any) {
       if (type in browserInterface) {
         // tslint:disable-next-line:semicolon
-        ; (browserInterface as any)[type](message)
+        ;(browserInterface as any)[type](message)
       } else {
         defaultLogger.info(`Unknown message (did you forget to add ${type} to unity-interface/dcl.ts?)`, message)
       }

--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -17,7 +17,8 @@ import {
   Profile,
   InstancedSpawnPoint,
   AvatarAsset,
-  Notification
+  Notification,
+  HUDConfiguration
 } from '../shared/types'
 import { DevTools } from '../shared/apis/DevTools'
 import { gridToWorld } from '../atomicHelpers/parcelScenePositions'
@@ -181,6 +182,15 @@ const unityInterface = {
   },
   ShowNotification(notification: Notification) {
     gameInstance.SendMessage('HUDController', 'ShowNotification', JSON.stringify(notification))
+  },
+  ConfigureMinimapHUD(configuration: HUDConfiguration) {
+    gameInstance.SendMessage('HUDController', 'ConfigureMinimapHUD', JSON.stringify(configuration))
+  },
+  ConfigureAvatarHUD(configuration: HUDConfiguration) {
+    gameInstance.SendMessage('HUDController', 'ConfigureAvatarHUD', JSON.stringify(configuration))
+  },
+  ConfigureNotificationHUD(configuration: HUDConfiguration) {
+    gameInstance.SendMessage('HUDController', 'ConfigureNotificationHUD', JSON.stringify(configuration))
   }
 }
 


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Adds kernel calls that configure the Unity HUDs

# Why? <!-- Explain the reason -->
Unity HUDs should not exist in builder mode, so kernel must be able to activate/deactivate them.

Can be tested with https://github.com/decentraland/unity-client/pull/919