### PR TITLE
fix: drop fragment identifier to connect to local comms server

### DIFF
--- a/packages/shared/comms/index.ts
+++ b/packages/shared/comms/index.ts
@@ -403,7 +403,8 @@ export async function connect(userId: string, network: ETHEREUM_NETWORK, auth: A
   let commsBroker: IBrokerConnection
 
   if (USE_LOCAL_COMMS) {
-    const commsUrl = document.location.toString().replace(/^http/, 'ws')
+    const location = document.location.toString()
+    const commsUrl = location.replace(/^http/, 'ws').substring(0, location.indexOf('#')) // drop fragment identifier
 
     const url = new URL(commsUrl)
     const qs = new URLSearchParams({


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
Local comms connection is throwing an error on log in, due to a fragment identifier coming from auth0 sign in, as web socket connection doesn't support it.
Dropping it before connecting to local comms server.