### PR TITLE
fix: simplify text on how to try a different version

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,8 @@ describe('My example test', function() {
 ### Testing with different renderers (unity engine builds)
 
 1. Visit https://www.npmjs.com/package/decentraland-renderer -> “versions” tab and choose the wanted deployment tag
-2. In the repo's root directory run the following commands:
-   - `npm install decentraland-renderer@[CHOSEN TAG]`
-   - `cp node_modules/decentraland-renderer/*.unityweb static/unity/Build/`
+2. In the repo's root directory run the following command: `npm install decentraland-renderer@[CHOSEN TAG]`
 3. Run `make watch` and the local kernel should already use the selected renderer
-
-Alternatively you can edit the /Makefile file and look up the `update` command:
-1. update the `npm install decentraland-renderer@latest` line with the wanted tag, for example: `npm install decentraland-renderer@dev-fix-bye-unity-gltf-math-classes`
-2. run `make update` and then `make watch`
 
 ## Copyright info
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ describe('My example test', function() {
 
 1. Visit https://www.npmjs.com/package/decentraland-renderer -> “versions” tab and choose the wanted deployment tag
 2. In the repo's root directory run the following command: `npm install decentraland-renderer@[CHOSEN TAG]`
-3. Run `make watch` and the local kernel should already use the selected renderer
+3. Run `make watch` and the local kernel should already use the selected renderer (make sure to restart it if you are already running it).
 
 ## Copyright info
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ describe('My example test', function() {
 1. Visit https://www.npmjs.com/package/decentraland-renderer -> “versions” tab and choose the wanted deployment tag
 2. In the repo's root directory run the following command: `npm install decentraland-renderer@[CHOSEN TAG]`
 3. Run `make watch` and the local kernel should already use the selected renderer (make sure to restart it if you are already running it).
+4. Whenever the `npm` tag is changed and you would like to update that, run `npm install decentraland-renderer@[CHOSEN TAG]` again!
 
 ## Copyright info
 


### PR DESCRIPTION
Given that both ˋmake watchˋ (after this PR: #544) and ˋnpm installˋ (before the PR) automatically copy the files, doing the ˋcpˋ is not necessary (unless you don't restart ˋmake watchˋ).