### PR TITLE
fix: using tab focus aware timers

### DIFF
--- a/packages/shared/timers/Timer.ts
+++ b/packages/shared/timers/Timer.ts
@@ -1,0 +1,30 @@
+export class Timer {
+  private timerId: any
+  private start: number
+  private remaining: number
+
+  constructor(private callback: Function, delay: number) {
+    this.remaining = delay
+    this.start = Date.now()
+  }
+
+  resume() {
+    this.start = Date.now()
+    window.clearTimeout(this.timerId)
+    this.timerId = window.setTimeout(() => {
+      this.callback(this)
+    }, this.remaining)
+  }
+
+  pause() {
+    window.clearTimeout(this.timerId)
+    this.remaining -= Date.now() - this.start
+  }
+
+  cancel() {
+    window.clearTimeout(this.timerId)
+    this.remaining = 0
+    this.start = 0
+    this.timerId = undefined
+  }
+}

--- a/packages/shared/timers/index.ts
+++ b/packages/shared/timers/index.ts
@@ -19,9 +19,9 @@ const timers = new Set<Timer>()
 
 function handleVisibilityChange() {
   if (isForeground()) {
-    ;[...timers].forEach($ => $.resume())
+    [...timers].forEach($ => $.resume())
   } else {
-    ;[...timers].forEach($ => $.pause())
+    [...timers].forEach($ => $.pause())
   }
 }
 

--- a/packages/shared/timers/index.ts
+++ b/packages/shared/timers/index.ts
@@ -1,0 +1,59 @@
+import { Timer } from './Timer'
+
+let hidden: 'hidden' | 'msHidden' | 'webkitHidden' = 'hidden'
+let visibilityChange: 'visibilitychange' | 'msvisibilitychange' | 'webkitvisibilitychange' = 'visibilitychange'
+
+if (typeof (document as any).hidden !== 'undefined') {
+  // Opera 12.10 and Firefox 18 and later support
+  hidden = 'hidden'
+  visibilityChange = 'visibilitychange'
+} else if (typeof (document as any).msHidden !== 'undefined') {
+  hidden = 'msHidden'
+  visibilityChange = 'msvisibilitychange'
+} else if (typeof (document as any).webkitHidden !== 'undefined') {
+  hidden = 'webkitHidden'
+  visibilityChange = 'webkitvisibilitychange'
+}
+
+const timers = new Set<Timer>()
+
+function handleVisibilityChange() {
+  if (isForeground()) {
+    ;[...timers].forEach($ => $.resume())
+  } else {
+    ;[...timers].forEach($ => $.pause())
+  }
+}
+
+if (hidden && visibilityChange) {
+  document.addEventListener(visibilityChange, handleVisibilityChange, false)
+}
+
+function register(timer: Timer) {
+  timers.add(timer)
+}
+
+function unregister(timer: Timer) {
+  timers.delete(timer)
+}
+
+function isForeground() {
+  return !(document as any)[hidden]
+}
+
+export function setForegroundTimeout(callback: Function, delay: number) {
+  const timer = new Timer((self: Timer) => {
+    callback()
+    unregister(self)
+  }, delay)
+  register(timer)
+  if (isForeground()) {
+    timer.resume()
+  }
+  return timer
+}
+
+export function clearForegroundTimeout(timer: Timer) {
+  timer.cancel()
+  unregister(timer)
+}

--- a/packages/shared/world/parcelSceneManager.ts
+++ b/packages/shared/world/parcelSceneManager.ts
@@ -10,6 +10,7 @@ import { sceneLifeCycleObservable } from '../../decentraland-loader/lifecycle/co
 import { worldRunningObservable } from './worldState'
 import { queueTrackingEvent } from '../analytics'
 import { ParcelSceneAPI } from './ParcelSceneAPI'
+import { setForegroundTimeout, clearForegroundTimeout } from '../timers/index'
 
 export type EnableParcelSceneLoadingOptions = {
   parcelSceneClass: { new (x: EnvironmentData<LoadableParcelScene>): ParcelSceneAPI }
@@ -89,9 +90,12 @@ export async function enableParcelSceneLoading(options: EnableParcelSceneLoading
       loadParcelScene(parcelScene)
     }
 
+    let timer: any
+
     const observer = sceneLifeCycleObservable.add(sceneStatus => {
       if (sceneStatus.sceneId === sceneId) {
         sceneLifeCycleObservable.remove(observer)
+        clearForegroundTimeout(timer)
         ret.notify('Scene.status', sceneStatus)
       }
     })
@@ -101,7 +105,7 @@ export async function enableParcelSceneLoading(options: EnableParcelSceneLoading
       options.onLoadParcelScenes([await ret.getParcelData(sceneId)])
     }
 
-    setTimeout(() => {
+    timer = setForegroundTimeout(() => {
       const worker = getSceneWorkerBySceneID(sceneId)
       if (worker && !worker.sceneStarted) {
         sceneLifeCycleObservable.remove(observer)


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->
Fixes https://github.com/decentraland/unity-client/issues/899.

# What? <!-- what is this PR? -->
Fixes world load timeouts when in background.

# Why? <!-- Explain the reason -->
Current timeouts don't take into account that browsers will throttle the CPU usage while in background (other tabs active). Therefore after the timeout has passed, the user encounters an empty world.
This fix includes making these timers aware of this fact, pausing themselves when in background.
