### PR TITLE
fix: persisting own profile as the peer ones

### DIFF
--- a/packages/shared/comms/index.ts
+++ b/packages/shared/comms/index.ts
@@ -7,7 +7,6 @@ import { MessageEntry } from 'shared/types'
 import { positionObservable, PositionReport } from 'shared/world/positionThings'
 import 'webrtc-adapter'
 import { PassportAsPromise } from '../passports/PassportAsPromise'
-import { Profile } from '../passports/types'
 import { BrokerConnection } from './BrokerConnection'
 import { ChatEvent, chatObservable } from './chat'
 import { CliBrokerConnection } from './CliBrokerConnection'
@@ -155,7 +154,7 @@ export function processParcelSceneCommsMessage(context: Context, fromAlias: stri
   }
 }
 
-export function persistCurrentUser(changes: Partial<Profile>): Readonly<UserInformation> {
+export function persistCurrentUser(changes: Partial<UserInformation>): Readonly<UserInformation> {
   const peer = getCurrentPeer()
 
   if (!peer || !localProfileUUID) throw new Error('cannotGetCurrentPeer')
@@ -210,13 +209,7 @@ export function processChatMessage(context: Context, fromAlias: string, data: Ch
   }
 }
 
-export function processProfileMessage(
-  auth: Auth,
-  context: Context,
-  fromAlias: string,
-  identity: string,
-  data: ProfileData
-) {
+export function processProfileMessage(context: Context, fromAlias: string, identity: string, data: ProfileData) {
   const msgTimestamp = data.getTime()
 
   const peerTrackingInfo = ensurePeerTrackingInfo(context, fromAlias)
@@ -447,7 +440,7 @@ export async function connect(userId: string, network: ETHEREUM_NETWORK, auth: A
     processPositionMessage(context!, alias, data)
   }
   connection.profileHandler = (alias: string, identity: string, data: ProfileData) => {
-    processProfileMessage(auth, context!, alias, identity, data)
+    processProfileMessage(context!, alias, identity, data)
   }
   connection.chatHandler = (alias: string, data: ChatData) => {
     processChatMessage(context!, alias, data)

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -25,6 +25,7 @@ import { buildStore } from './store/store'
 import { getAppNetwork, getNetworkFromTLD, initWeb3 } from './web3'
 import { initializeUrlPositionObserver } from './world/positionThings'
 import { setWorldContext } from './protocol/actions'
+import { profileToRendererFormat } from './passports/transformations/profileToRendererFormat'
 
 // TODO fill with segment keys and integrate identity server
 async function initializeAnalytics(userId: string) {
@@ -134,7 +135,11 @@ export async function initShared(): Promise<Session | undefined> {
   console['group']('connect#profile')
   if (!PREVIEW) {
     const profile = await PassportAsPromise(localProfileUUID!)
-    persistCurrentUser({ userId: localProfileUUID!, version: profile.version, ...profile })
+    persistCurrentUser({
+      userId: localProfileUUID!,
+      version: profile.version,
+      profile: profileToRendererFormat(profile)
+    })
   }
   console['groupEnd']()
 

--- a/test/unit/communications.test.tsx
+++ b/test/unit/communications.test.tsx
@@ -538,9 +538,6 @@ describe('Communications', function () {
           })
         }
       })
-      const fakeAuth: any = {
-        getAccessToken: () => Promise.resolve('access_token')
-      }
       it('new profile message', () => {
         const context = new Context({})
 
@@ -552,7 +549,7 @@ describe('Communications', function () {
         sinon.spy(info, 'loadProfileIfNecessary')
         context.peerData.set('client2', info)
 
-        processProfileMessage(fakeAuth, context, 'client2', 'userId1', profileData)
+        processProfileMessage(context, 'client2', 'userId1', profileData)
 
         expect(context.peerData).to.have.key('client2')
         const trackingInfo = context.peerData.get('client2') as PeerTrackingInfo
@@ -575,7 +572,7 @@ describe('Communications', function () {
         profileData.setTime(new Date(2008).getTime())
         profileData.setProfileVersion('2')
 
-        processProfileMessage(fakeAuth, context, 'client2', 'identity2', profileData)
+        processProfileMessage(context, 'client2', 'identity2', profileData)
 
         expect(context.peerData).to.have.key('client2')
         const trackingInfo = context.peerData.get('client2') as PeerTrackingInfo


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->
Fixes partly #485.

# What? <!-- what is this PR? -->
- Persisting own profile in the same format as peers
- Using `ProfileForRenderer` instead of `Profile` to avoid differences
- Removing auth client from connection method signature

# Why? <!-- Explain the reason -->
The user profile was being persisted in a different format from the rest of the peers and this made it err in a fresh client login as the profile could not be found on chat (`profileNotInitialized` issue), thus own messages were never sent or shown.
