### PR TITLE
chore: remove timeout in preview

### DIFF
--- a/packages/entryPoints/preview.ts
+++ b/packages/entryPoints/preview.ts
@@ -64,16 +64,9 @@ function startPreviewWatcher() {
 function sceneRenderable() {
   const sceneRenderable = future<void>()
 
-  const timer = setTimeout(() => {
-    if (sceneRenderable.isPending) {
-      sceneRenderable.reject(new Error('scene never got ready'))
-    }
-  }, 30000)
-
   const observer = sceneLifeCycleObservable.add(async sceneStatus => {
     if (sceneStatus.sceneId === (await defaultScene).sceneId) {
       sceneLifeCycleObservable.remove(observer)
-      clearTimeout(timer)
       sceneRenderable.resolve()
     }
   })


### PR DESCRIPTION
<!-- 
Please refer to the issue or JIRA ticket to close like `Closes #14` or 
`Fixes [CLIENT-1]`
-->

# What? <!-- what is this PR? -->
As of today we have a timeout in preview mode which errs in case the scene is not ready in 30 seconds. This timeout proves to be useless as the user is only waiting for this scene to load and it should still be able to load in a bigger amount of time.