### PR TITLE
fix: builder's scene reset

### DIFF
--- a/packages/entryPoints/editor.ts
+++ b/packages/entryPoints/editor.ts
@@ -52,7 +52,7 @@ async function createBuilderScene(scene: IScene & { baseUrl: string }) {
   if (isFirstRun) {
     unityInterface.SetBuilderReady()
   } else {
-    unityInterface.ResetBuilderObject()
+    unityInterface.ResetBuilderScene()
   }
   await builderSceneLoaded
 


### PR DESCRIPTION
Builder's scene was not reset properly when after changing scene (wrong method was called)