### PR TITLE
chore: update client renderer package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2530,9 +2530,9 @@
       }
     },
     "decentraland-renderer": {
-      "version": "1.7.941",
-      "resolved": "https://registry.npmjs.org/decentraland-renderer/-/decentraland-renderer-1.7.941.tgz",
-      "integrity": "sha512-ZzzasmNZ6CCMIsSFv2TX7cFkpnyCvhRqGU0+hwi7FjW9E8dPY1tCizO/k80tn0V3KY9MZ9P0AZZsGyqS5jZg6Q=="
+      "version": "1.7.963",
+      "resolved": "https://registry.npmjs.org/decentraland-renderer/-/decentraland-renderer-1.7.963.tgz",
+      "integrity": "sha512-4yZG36EqfzAsTt5BqPbMLAfnbSh4qpvWX3r1b41AzWPHBqSUoflzJnioclDq7UGUjXlrYcP/q3hCaZovso49mw=="
     },
     "decentraland-rpc": {
       "version": "3.1.8",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "body-scroll-lock": "^2.5.10",
     "concurrently": "^4.1.0",
     "decentraland-auth-protocol": "^0.3.2",
-    "decentraland-renderer": "^1.7.941",
+    "decentraland-renderer": "^1.7.963",
     "decentraland-rpc": "^3.1.8",
     "devtools-protocol": "0.0.615714",
     "ephemeralkey": "^1.3.0",


### PR DESCRIPTION
Updated decentraland-renderer package to point to the latest client renderer

