### PR TITLE
chore: drop tslint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,10 +209,8 @@ watch-cli: build-essentials ## Watch the files required for building the CLI
 lint: ## Validate correct formatting and circular dependencies
 	@node_modules/.bin/madge packages/entryPoints/unity.ts --circular --warning
 	@node_modules/.bin/madge packages --orphans --extensions ts --exclude '.+\.d.ts|.+/dist\/.+'
-	@node_modules/.bin/tslint --project tsconfig.json
 
 lint-fix: ## Fix bad formatting on all .ts and .tsx files
-	@node_modules/.bin/tslint --project tsconfig.json --fix
 	@node_modules/.bin/prettier --write 'packages/**/*.{ts,tsx}'
 
 # Development


### PR DESCRIPTION
TSLint is EOL next year https://medium.com/palantir/tslint-in-2019-1a144c2317a9