### PR TITLE
fix: builder don't need entity id  when calling for deselection

### DIFF
--- a/packages/entryPoints/editor.ts
+++ b/packages/entryPoints/editor.ts
@@ -195,8 +195,8 @@ namespace editor {
     unityInterface.SelectBuilderEntity(entityId)
   }
 
-  export function deselectEntity(entityId: string) {
-    unityInterface.DeselectBuilderEntity(entityId)
+  export function deselectEntity() {
+    unityInterface.DeselectBuilderEntity()
   }
 
   export function getDCLCanvas() {

--- a/packages/unity-interface/dcl.ts
+++ b/packages/unity-interface/dcl.ts
@@ -326,8 +326,8 @@ export const unityInterface = {
   OnBuilderKeyDown(key: string) {
     this.SendBuilderMessage('OnBuilderKeyDown', key)
   },
-  DeselectBuilderEntity(entityId: string) {
-    this.SendBuilderMessage('DeselectBuilderEntity', entityId)
+  DeselectBuilderEntity() {
+    this.SendBuilderMessage('DeselectBuilderEntity')
   }
 }
 


### PR DESCRIPTION
It will make @belohlavek life easier if there is no need to send as payload the entity's id when calling for deselection
